### PR TITLE
Add telegram read/write CLI scripts for agent use

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,3 +2,6 @@
 # Get these from https://my.telegram.org/apps
 TELEGRAM_API_ID=
 TELEGRAM_API_HASH=
+
+# Optional: default topic for tg-send.ts (name substring or numeric ID)
+# TELEGRAM_WRITE_TOPIC=agents

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,11 +101,14 @@ See [docs/research/peer-research-protocol.md](docs/research/peer-research-protoc
 
 | Script | What it does | Docs |
 |--------|-------------|------|
-| `sync_telegram.ts` | Pulls Telegram group thread messages to JSON | [docs/tooling/automation.md](docs/tooling/automation.md) |
+| `sync_telegram.ts` | Bulk-syncs Telegram topics to JSON files | [docs/tooling/automation.md](docs/tooling/automation.md) |
+| `telegram/tg-topics.ts` | Lists forum topics (JSON) | See below |
+| `telegram/tg-read.ts` | Reads messages from a topic (JSON) | See below |
+| `telegram/tg-send.ts` | Sends a message to a topic | See below |
 | `src/sync_google_docs.py` | Pulls Google Docs to local markdown | [docs/tooling/automation.md](docs/tooling/automation.md) |
 | `.traces/export_sessions.py` | Exports Claude Code session traces | [docs/tooling/automation.md](docs/tooling/automation.md) |
 
-### Telegram Sync Quick Reference
+### Telegram Quick Reference
 
 ```bash
 # First time: install deps and authenticate
@@ -113,9 +116,26 @@ bun install
 cp .env.example .env  # fill in TELEGRAM_API_ID and TELEGRAM_API_HASH
 tg auth login
 
-# Sync messages
+# Bulk sync (existing)
 bun run sync_telegram.ts
-# Output: src/sparse_parity/telegram_sync/messages.json
+
+# List topics
+bun telegram/tg-topics.ts
+
+# Read last 20 messages from a topic
+bun telegram/tg-read.ts --topic "General" --limit 20
+
+# Read messages since a date
+bun telegram/tg-read.ts --topic "chat-yad" --since 2025-06-01
+
+# Send a message to a topic
+bun telegram/tg-send.ts --topic "agents" --message "Hello from agent"
+
+# Send multi-line via stdin
+echo "Summary of findings..." | bun telegram/tg-send.ts --topic "agents" --stdin
+
+# Send to default write topic (set TELEGRAM_WRITE_TOPIC in .env)
+bun telegram/tg-send.ts --message "Status update"
 ```
 
 ## Working Style

--- a/telegram/client.ts
+++ b/telegram/client.ts
@@ -1,0 +1,35 @@
+import { TelegramClient } from "@mtcute/bun";
+import { tl } from "@mtcute/tl";
+import { existsSync } from "fs";
+import { API_ID, API_HASH, SESSION_PATH, CHANNEL_USERNAME } from "./config.ts";
+
+export async function getClient() {
+  if (!API_ID || !API_HASH) {
+    console.error("Set TELEGRAM_API_ID and TELEGRAM_API_HASH in .env");
+    process.exit(1);
+  }
+
+  if (!existsSync(SESSION_PATH)) {
+    console.error(
+      `Session not found at ${SESSION_PATH}. Run 'tg auth login' first.`
+    );
+    process.exit(1);
+  }
+
+  const client = new TelegramClient({
+    apiId: API_ID,
+    apiHash: API_HASH,
+    storage: SESSION_PATH,
+  });
+
+  await client.start();
+
+  const peer = await client.resolvePeer(CHANNEL_USERNAME);
+  const inputChannel: tl.TypeInputChannel = {
+    _: "inputChannel",
+    channelId: (peer as tl.RawInputPeerChannel).channelId,
+    accessHash: (peer as tl.RawInputPeerChannel).accessHash,
+  };
+
+  return { client, peer, inputChannel };
+}

--- a/telegram/config.ts
+++ b/telegram/config.ts
@@ -1,0 +1,10 @@
+import { join } from "path";
+import { homedir } from "os";
+
+export const CHANNEL_USERNAME = process.env.TELEGRAM_CHANNEL ?? "sutro_group";
+export const SESSION_PATH =
+  process.env.TELEGRAM_SESSION ??
+  join(homedir(), ".telegram-sync-cli", "session_1.db");
+export const API_ID = parseInt(process.env.TELEGRAM_API_ID ?? "0", 10);
+export const API_HASH = process.env.TELEGRAM_API_HASH ?? "";
+export const WRITE_TOPIC = process.env.TELEGRAM_WRITE_TOPIC ?? "";

--- a/telegram/resolve-topic.ts
+++ b/telegram/resolve-topic.ts
@@ -1,0 +1,49 @@
+import { TelegramClient } from "@mtcute/bun";
+import { tl } from "@mtcute/tl";
+
+export async function getForumTopics(
+  client: TelegramClient,
+  inputChannel: tl.TypeInputChannel
+): Promise<tl.RawForumTopic[]> {
+  const topics = await client.call({
+    _: "channels.getForumTopics",
+    channel: inputChannel,
+    limit: 100,
+    offsetDate: 0,
+    offsetId: 0,
+    offsetTopic: 0,
+  });
+
+  return (topics as tl.RawMessagesForumTopics).topics.filter(
+    (t): t is tl.RawForumTopic => t._ === "forumTopic"
+  );
+}
+
+export async function resolveTopic(
+  client: TelegramClient,
+  inputChannel: tl.TypeInputChannel,
+  topicArg: string
+): Promise<{ id: number; title: string }> {
+  // If numeric, use directly
+  const asNumber = parseInt(topicArg, 10);
+  if (!isNaN(asNumber) && String(asNumber) === topicArg.trim()) {
+    // Still fetch topics to get the title
+    const topics = await getForumTopics(client, inputChannel);
+    const match = topics.find((t) => t.id === asNumber);
+    return { id: asNumber, title: match?.title ?? `topic-${asNumber}` };
+  }
+
+  // Otherwise, match by case-insensitive substring
+  const topics = await getForumTopics(client, inputChannel);
+  const match = topics.find((t) =>
+    t.title.toLowerCase().includes(topicArg.toLowerCase())
+  );
+
+  if (!match) {
+    const available = topics.map((t) => `  - ${t.title} (${t.id})`).join("\n");
+    console.error(`No topic matching "${topicArg}". Available:\n${available}`);
+    process.exit(1);
+  }
+
+  return { id: match.id, title: match.title };
+}

--- a/telegram/tg-read.ts
+++ b/telegram/tg-read.ts
@@ -1,0 +1,97 @@
+#!/usr/bin/env bun
+// Read messages from a Telegram forum topic.
+// Usage: bun telegram/tg-read.ts --topic "General" --limit 20
+//        bun telegram/tg-read.ts --topic 123 --limit 50 --since 2025-01-01
+// Output: JSON array of { id, date, sender, text, replyTo }
+
+import { tl } from "@mtcute/tl";
+import { parseArgs } from "util";
+import { getClient } from "./client.ts";
+import { resolveTopic } from "./resolve-topic.ts";
+
+const { values } = parseArgs({
+  args: Bun.argv.slice(2),
+  options: {
+    topic: { type: "string" },
+    limit: { type: "string", default: "50" },
+    since: { type: "string" },
+  },
+});
+
+if (!values.topic) {
+  console.error("Usage: bun tg-read.ts --topic <name|id> [--limit N] [--since ISO-date]");
+  process.exit(1);
+}
+
+const limit = parseInt(values.limit!, 10);
+const sinceDate = values.since ? new Date(values.since).getTime() / 1000 : 0;
+
+const { client, peer, inputChannel } = await getClient();
+const topic = await resolveTopic(client, inputChannel, values.topic);
+
+// Fetch messages with pagination (adapted from sync_telegram.ts)
+const allMessages: tl.RawMessage[] = [];
+const users = new Map<number, string>();
+let offsetId = 0;
+const BATCH_SIZE = 100;
+
+while (allMessages.length < limit) {
+  const history = await client.call({
+    _: "messages.getReplies",
+    peer,
+    msgId: topic.id,
+    offsetId,
+    offsetDate: 0,
+    addOffset: 0,
+    limit: Math.min(BATCH_SIZE, limit - allMessages.length),
+    maxId: 0,
+    minId: 0,
+    hash: 0,
+  });
+
+  const resp = history as tl.RawMessagesChannelMessages;
+
+  if ("users" in resp) {
+    for (const u of resp.users) {
+      if (u._ === "user") {
+        users.set(u.id, [u.firstName, u.lastName].filter(Boolean).join(" "));
+      }
+    }
+  }
+
+  const msgs = resp.messages.filter(
+    (m): m is tl.RawMessage => m._ === "message"
+  );
+
+  if (msgs.length === 0) break;
+
+  for (const m of msgs) {
+    if (sinceDate && m.date < sinceDate) {
+      // Messages are newest-first; once we pass the cutoff, stop
+      break;
+    }
+    allMessages.push(m);
+    if (allMessages.length >= limit) break;
+  }
+
+  // If we hit the since cutoff, stop paginating
+  if (sinceDate && msgs[msgs.length - 1].date < sinceDate) break;
+
+  offsetId = msgs[msgs.length - 1].id;
+  await new Promise((r) => setTimeout(r, 500));
+}
+
+const output = allMessages.map((m) => ({
+  id: m.id,
+  date: new Date(m.date * 1000).toISOString(),
+  sender:
+    users.get(
+      Number(m.fromId && "userId" in m.fromId ? m.fromId.userId : 0)
+    ) ?? String(m.fromId),
+  text: m.message,
+  replyTo:
+    m.replyTo && "replyToMsgId" in m.replyTo ? m.replyTo.replyToMsgId : null,
+}));
+
+console.log(JSON.stringify(output, null, 2));
+process.exit(0);

--- a/telegram/tg-send.ts
+++ b/telegram/tg-send.ts
@@ -1,0 +1,80 @@
+#!/usr/bin/env bun
+// Send a message to a Telegram forum topic.
+// Usage: bun telegram/tg-send.ts --topic "agents" --message "Hello from agent"
+//        echo "Multi-line msg" | bun telegram/tg-send.ts --topic "agents" --stdin
+//        bun telegram/tg-send.ts --message "Hello"   # uses TELEGRAM_WRITE_TOPIC
+// Output: JSON { ok, topicId, topicTitle }
+
+import { parseArgs } from "util";
+import { getClient } from "./client.ts";
+import { resolveTopic } from "./resolve-topic.ts";
+import { WRITE_TOPIC } from "./config.ts";
+
+const { values } = parseArgs({
+  args: Bun.argv.slice(2),
+  options: {
+    topic: { type: "string" },
+    message: { type: "string" },
+    stdin: { type: "boolean", default: false },
+  },
+});
+
+const topicArg = values.topic || WRITE_TOPIC;
+if (!topicArg) {
+  console.error(
+    "Specify --topic <name|id> or set TELEGRAM_WRITE_TOPIC in .env"
+  );
+  process.exit(1);
+}
+
+let message: string;
+if (values.stdin) {
+  message = await Bun.stdin.text();
+} else if (values.message) {
+  message = values.message;
+} else {
+  console.error("Provide --message <text> or --stdin");
+  process.exit(1);
+}
+
+message = message.trim();
+if (!message) {
+  console.error("Message is empty");
+  process.exit(1);
+}
+
+const { client, peer, inputChannel } = await getClient();
+const topic = await resolveTopic(client, inputChannel, topicArg);
+
+const sendMessage = async () => {
+  await client.call({
+    _: "messages.sendMessage",
+    peer,
+    message,
+    replyTo: {
+      _: "inputReplyToMessage",
+      replyToMsgId: topic.id,
+      topMsgId: topic.id,
+    },
+    randomId: BigInt(crypto.getRandomValues(new BigInt64Array(1))[0]),
+  });
+};
+
+try {
+  await sendMessage();
+} catch (e: any) {
+  // Handle FLOOD_WAIT: sleep and retry once
+  if (e?.errorMessage?.startsWith?.("FLOOD_WAIT_")) {
+    const seconds = parseInt(e.errorMessage.split("_").pop(), 10) || 5;
+    console.error(`Rate limited, waiting ${seconds}s...`);
+    await new Promise((r) => setTimeout(r, seconds * 1000));
+    await sendMessage();
+  } else {
+    throw e;
+  }
+}
+
+console.log(
+  JSON.stringify({ ok: true, topicId: topic.id, topicTitle: topic.title })
+);
+process.exit(0);

--- a/telegram/tg-topics.ts
+++ b/telegram/tg-topics.ts
@@ -1,0 +1,14 @@
+#!/usr/bin/env bun
+// List all forum topics in the Telegram group.
+// Usage: bun telegram/tg-topics.ts
+// Output: JSON array of { id, title }
+
+import { getClient } from "./client.ts";
+import { getForumTopics } from "./resolve-topic.ts";
+
+const { client, inputChannel } = await getClient();
+const topics = await getForumTopics(client, inputChannel);
+
+const output = topics.map((t) => ({ id: t.id, title: t.title }));
+console.log(JSON.stringify(output, null, 2));
+process.exit(0);


### PR DESCRIPTION
## Summary

- Adds three lightweight CLI scripts in `telegram/` that let AI agents read and write to Telegram forum topics via MTProto
- Reuses the existing `@mtcute/bun` stack from `sync_telegram.ts` — no new dependencies
- Shared helpers (`client.ts`, `config.ts`, `resolve-topic.ts`) extract connection and topic resolution logic for reuse

### New scripts

| Script | Purpose |
|--------|---------|
| `bun telegram/tg-topics.ts` | List forum topics as JSON |
| `bun telegram/tg-read.ts --topic "General" --limit 20` | Read messages from a topic |
| `bun telegram/tg-send.ts --topic "agents" --message "Hello"` | Send a message to a topic |

### Why not MCP?

These are plain CLI scripts that output JSON to stdout — agents invoke them via `bun telegram/tg-send.ts ...` in a shell. No MCP server, no protocol overhead, no persistent process. Much lighter on tokens than an MCP integration.

### Send to forum topics

Uses `messages.sendMessage` with `replyTo.topMsgId` set to the forum topic ID — the same raw MTProto approach the existing read code uses. Supports `--stdin` for multi-line messages and `TELEGRAM_WRITE_TOPIC` env var for a default write target.

## Test plan

- [ ] `bun telegram/tg-topics.ts` lists forum topics as JSON
- [ ] `bun telegram/tg-read.ts --topic "General" --limit 5` returns recent messages
- [ ] `bun telegram/tg-send.ts --topic "General" --message "test"` sends and appears in Telegram
- [ ] Verify `--stdin` mode works for multi-line messages
- [ ] Verify `TELEGRAM_WRITE_TOPIC` default works when `--topic` is omitted

🤖 Generated with [Claude Code](https://claude.com/claude-code)