### PR TITLE
Add cross-model research supervisor (bin/review-cycle)

### DIFF
--- a/.codex/AGENTS.md
+++ b/.codex/AGENTS.md
@@ -1,0 +1,92 @@
+# Codex Project Instructions
+
+These instructions apply to all Codex CLI sessions in this repo.
+
+## Before Any Research Task
+
+Load current project state before running experiments, reviewing PRs, or writing findings.
+
+1. Read these files in order:
+   - **CODEX.md** -- project context, current best methods, constraints
+   - **DISCOVERIES.md** -- what's proven, what failed, open questions (bottom of file)
+   - **AGENT.md** -- machine-executable experiment loop (if running autonomous)
+   - **LAB.md** -- experiment protocol, rules (especially rule #9: metric isolation)
+
+2. Check recent Telegram activity (if synced):
+
+```python
+import json
+for f in ['chat-yad.json', 'chat-yaroslav.json', 'challenge-1-sparse-parity.json']:
+    path = f'src/sparse_parity/telegram_sync/{f}'
+    try:
+        msgs = json.load(open(path))
+        print(f'\n=== {f} (last 3) ===')
+        for m in msgs[:3]:
+            print(f"  [{m['date'][:10]}] {m['sender']}: {m['text'][:150]}")
+    except FileNotFoundError:
+        print(f'{f} not found -- run: bun run sync_telegram.ts')
+```
+
+3. Check GitHub for open work:
+
+```bash
+gh pr list --repo cybertronai/SutroYaro --state open
+gh issue list --repo cybertronai/SutroYaro --state open
+```
+
+4. Before writing code, check:
+   - `research/search_space.yaml` for allowed parameter ranges
+   - `research/questions.yaml` for the dependency graph of open questions
+
+## Current State
+
+| Fact | Value |
+|------|-------|
+| Best method | GF(2) Gaussian elimination, 509us, ARD ~500 |
+| Best energy proxy | DMC (Data Movement Complexity, Ding et al.) |
+| Experiments done | 33+ (see `research/log.jsonl`) |
+| Open questions | Bottom of DISCOVERIES.md (Q7, Q11-Q13 still open) |
+| Next milestone | Energy-efficient nanoGPT training ("final exam") |
+| Meeting cadence | Mondays 18:00 at South Park Commons |
+
+## Sync Routine
+
+Run at session start and before any push:
+
+```bash
+# Telegram (daily)
+bun run sync_telegram.ts
+
+# Or use the targeted read/send scripts:
+bun telegram/tg-read.ts --topic "General" --limit 10
+bun telegram/tg-send.ts --topic "agents" --message "Status update"
+
+# Google Docs (weekly, after Monday meetings)
+python3 src/sync_google_docs.py
+
+# GitHub
+gh pr list --repo cybertronai/SutroYaro --state open
+gh issue list --repo cybertronai/SutroYaro --state open
+```
+
+Before pushing:
+1. Update `docs/changelog.md` (bump version)
+2. `python3 -m mkdocs build` to verify no broken links
+3. Show the diff and wait for approval before `git push`
+
+## Writing Rules (Anti-Slop)
+
+Apply these to all prose (findings docs, DISCOVERIES.md updates, PR descriptions):
+
+1. Cut filler phrases. Say the thing directly.
+2. Break formulaic structures. No binary contrasts, no dramatic fragmentation.
+3. Vary rhythm. Mix sentence lengths. Two items beat three.
+4. Trust readers. State facts directly.
+5. Prefer plain verbs. "used" not "leveraged," "showed" not "showcased."
+6. Use simple copulatives. Write "X is Y" not "X serves as Y."
+7. Kill em dashes. Use commas or periods.
+8. Never triple. Two items in a list, not three.
+9. Be specific. Replace generic statements with concrete details.
+10. No AI vocabulary: delve, tapestry, landscape, pivotal, showcase, testament, underscore, foster, garner, interplay, intricate, vibrant, robust, seamless, paramount, multifaceted, nuanced, groundbreaking, cornerstone, transformative, synergy.
+
+Full guide: `.claude/skills/anti-slop-guide/SKILL.md` (plain markdown, readable by any tool).

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,0 +1,16 @@
+# Codex CLI project config for SutroYaro
+# Docs: https://developers.openai.com/codex/config-reference
+
+model = "codex-1"
+
+# Workspace-write lets the agent edit files and run experiments
+sandbox_mode = "workspace-write"
+
+# Ask before destructive actions (git push, file deletion)
+approval_policy = "on-request"
+
+# Read CODEX.md for project context (in addition to AGENTS.md which is auto-read)
+project_doc_fallback_filenames = ["CODEX.md", "AGENTS.md"]
+
+# Auth: prefer ChatGPT OAuth (uses subscription, not API credits)
+forced_login_method = "chatgpt"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # AGENTS.md
 
-This project uses AI agents (Claude Code, Gemini, Replit, others) for research and accepts contributions from both humans and agents.
+This project uses AI agents (Claude Code, Codex CLI, Gemini CLI, Replit, others) for research and accepts contributions from both humans and agents.
 
 ## How AI agents were used
 
@@ -33,7 +33,9 @@ When reviewing a contributed experiment:
 
 | File | Purpose |
 |------|---------|
-| `CLAUDE.md` | Project instructions loaded at session start |
+| `CLAUDE.md` | Project context for Claude Code (auto-loaded at session start) |
+| `CODEX.md` | Project context for Codex CLI (auto-loaded via `.codex/config.toml`) |
+| `.codex/AGENTS.md` | Codex instructions: context loading, sync routine, writing rules |
 | `LAB.md` | Experiment protocol (one hypothesis, baseline, commit discipline) |
 | `DISCOVERIES.md` | Shared knowledge base, anyone can PR new findings |
 | `CONTRIBUTING.md` | How humans and agents contribute (three effort levels) |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,6 +45,8 @@ When reviewing a contributed experiment:
 | `docs/research/survey.md` | Full methodology in Section 7 (agentic loop, parallel dispatch, prompting strategies) |
 | `docs/tooling/anti-slop-guide.md` | Writing rules applied to all agent-generated prose |
 | `docs/tooling/sync-runbook.md` | Weekly/daily/per-session sync checklists |
+| `bin/review-cycle` | Cross-model supervisor: reviews experiments, dialogues with researcher |
+| `research/reviews/` | Review dialogue files (one per review cycle) |
 
 ## What worked
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,6 +104,22 @@ See [docs/research/peer-research-protocol.md](docs/research/peer-research-protoc
 | `sync_telegram.ts` | Pulls Telegram group thread messages to JSON | [docs/tooling/automation.md](docs/tooling/automation.md) |
 | `src/sync_google_docs.py` | Pulls Google Docs to local markdown | [docs/tooling/automation.md](docs/tooling/automation.md) |
 | `.traces/export_sessions.py` | Exports Claude Code session traces | [docs/tooling/automation.md](docs/tooling/automation.md) |
+| `bin/review-cycle` | Cross-model experiment review (supervisor/researcher dialogue) | See below |
+
+### Review Cycle Quick Reference
+
+```bash
+# Codex supervises Claude's work (last 5 experiments, 3-turn dialogue)
+bin/review-cycle --tool codex --researcher-tool claude --last 5
+
+# Gemini supervises with more dialogue turns
+bin/review-cycle --tool gemini --researcher-tool claude --last 10 --turns 5
+
+# Preview prompts without launching agents
+bin/review-cycle --dry-run --last 3
+
+# Output: research/reviews/review-{timestamp}.md
+```
 
 ### Telegram Sync Quick Reference
 

--- a/CODEX.md
+++ b/CODEX.md
@@ -85,6 +85,22 @@ See [docs/research/peer-research-protocol.md](docs/research/peer-research-protoc
 | `telegram/tg-read.ts` | Reads messages from a topic (JSON) | See Telegram section below |
 | `telegram/tg-send.ts` | Sends a message to a topic | See Telegram section below |
 | `src/sync_google_docs.py` | Pulls Google Docs to local markdown | [docs/tooling/automation.md](docs/tooling/automation.md) |
+| `bin/review-cycle` | Cross-model experiment review (supervisor/researcher dialogue) | See below |
+
+### Review Cycle Quick Reference
+
+```bash
+# Codex supervises Claude's work (last 5 experiments, 3-turn dialogue)
+bin/review-cycle --tool codex --researcher-tool claude --last 5
+
+# Claude supervises Codex's work
+bin/review-cycle --tool claude --researcher-tool codex --last 5
+
+# Preview prompts without launching agents
+bin/review-cycle --dry-run --last 3
+
+# Output: research/reviews/review-{timestamp}.md
+```
 
 ### Telegram Quick Reference
 

--- a/CODEX.md
+++ b/CODEX.md
@@ -1,0 +1,160 @@
+# CODEX.md - Sutro Group Research Workspace
+
+## Project Context
+
+This is a research workspace for the **Sutro Group**, a study group exploring energy-efficient AI training. The group meets weekly at South Park Commons in San Francisco.
+
+## Read These First
+
+- **LAB.md** — Protocol for running experiments (templates, lifecycle, rules)
+- **AGENT.md** — Machine-executable experiment loop for autonomous sessions
+- **DISCOVERIES.md** — What's proven so far (read before every experiment)
+- **CONTRIBUTING.md** — How external contributors submit experiments and findings
+- **TODO.md** — Open research tasks
+- **docs/tasks/INDEX.md** — Current task tracker with priorities
+- **docs/research/survey.md** — Practitioner's Field Guide ranking all 33 experiments
+- **docs/research/peer-research-protocol.md** — Full design doc for multi-researcher autonomous research
+
+## Core Concepts
+
+- **Sparse Parity**: The benchmark task — learn XOR/parity from random {-1,+1} inputs. n=20 bits, k=3 secret, 17 noise. The "drosophila" of energy-efficient training.
+- **Average Reuse Distance (ARD)**: Proxy metric for energy efficiency. Small ARD = data stays in cache = cheap. Large ARD = expensive external memory access.
+- **Data Movement Complexity (DMC)**: Better proxy metric (Ding et al., arXiv:2312.14441). DMC = sum of sqrt(stack_distance) for all float accesses. Tracks alongside ARD in MemTracker. Baseline: ARD 4,104 / DMC 300,298.
+- **Cache Energy Model**: register 5pJ, L1 (64KB) 20pJ, L2 (256KB) 100pJ, HBM 640pJ per float access (Bill Dally numbers).
+- **CacheTracker**: Extended MemTracker with LRU cache simulation for realistic energy estimates.
+
+## Current Best Methods
+
+| Method | Time (n=20/k=3) | ARD | DMC | Notes |
+|--------|-----------------|-----|-----|-------|
+| KM-min (1 sample) | ~0.001s | 20 | 3,578 | New DMC leader. 1 influence sample suffices for parity. |
+| GF(2) Gaussian Elimination | 509 us | ~420 | 8,607 | 240x faster than SGD, k-independent. Harness under-counts; true DMC ~189K. |
+| KM Influence Estimation | 0.001-0.006s | 92 | 20,633 | ARD leader. 5 influence samples per bit. |
+| SMT Backtracking | 0.002s | 3,360 | 348,336 | Constraint satisfaction approach |
+| SGD (baseline) | 0.12s | 8,504 | 1,278,460 | LR=0.1, batch=32, hidden=200 |
+
+GF(2) solves n=100/k=10 in 703 microseconds. Parity is linear over the binary field -- the neural network was solving an easy problem the hard way.
+
+## SGD Config (when using neural nets)
+
+```python
+n_bits=20, k_sparse=3, hidden=200, lr=0.1, wd=0.01,
+batch_size=32, n_train=1000, max_epochs=200
+```
+
+Solves in ~40 epochs / 0.12s with numpy (`fast.py`).
+
+## Key Findings
+
+**Phase 1 (16 experiments, SGD optimization):**
+- LR=0.1 is critical (0.5 overshoots, never triggers phase transition)
+- W1 dominates 75% of all float reads -- limits ARD optimization to ~10%
+- L2 cache (256KB) eliminates ALL cache misses for both single-sample and batch
+- Curriculum learning (n=10 then expand to n=50) gives 14.6x speedup at scale
+- SGD breaks when n^k exceeds ~100,000 gradient steps
+
+**Phase 2 (17 experiments, broad search):**
+- Algebraic/exact methods (GF(2), KM, SMT) solve instantly -- they exploit that parity is linear over GF(2)
+- All 4 local learning rules (Hebbian, Predictive Coding, Equilibrium Propagation, Target Propagation) fail at chance level -- parity requires k-th order interaction detection
+- Information-theoretic methods (MI, LASSO, MDL, Random Projections) all solve it but none beats Fourier meaningfully
+- RL sequential Q-learning achieves ARD of 1 at inference (reads exactly k=3 bits per prediction)
+
+## Autonomous Research Infrastructure
+
+| File | Purpose |
+|------|---------|
+| `AGENT.md` | Agent-executable experiment loop (machine protocol) |
+| `src/harness.py` | Locked evaluation harness (DO NOT MODIFY in experiment PRs) |
+| `research/search_space.yaml` | Bounded mutation space per challenge |
+| `research/questions.yaml` | Dependency graph of open research questions |
+| `research/log.jsonl` | Append-only experiment log (machine-readable) |
+| `results/scoreboard.tsv` | Human-readable leaderboard (auto-generated) |
+| `checks/env_check.py` | Pre-flight environment check |
+| `checks/baseline_check.py` | Re-establish baselines on this machine |
+| `bin/run-agent` | Launch autonomous agent cycle |
+| `bin/merge-findings` | Import contributor log entries via PR |
+
+See [docs/research/peer-research-protocol.md](docs/research/peer-research-protocol.md) for the full design.
+
+## Automation
+
+| Script | What it does | Docs |
+|--------|-------------|------|
+| `sync_telegram.ts` | Bulk-syncs Telegram topics to JSON files | [docs/tooling/automation.md](docs/tooling/automation.md) |
+| `telegram/tg-topics.ts` | Lists forum topics (JSON) | See Telegram section below |
+| `telegram/tg-read.ts` | Reads messages from a topic (JSON) | See Telegram section below |
+| `telegram/tg-send.ts` | Sends a message to a topic | See Telegram section below |
+| `src/sync_google_docs.py` | Pulls Google Docs to local markdown | [docs/tooling/automation.md](docs/tooling/automation.md) |
+
+### Telegram Quick Reference
+
+```bash
+# First time: install deps and authenticate
+bun install
+cp .env.example .env  # fill in TELEGRAM_API_ID and TELEGRAM_API_HASH
+tg auth login
+
+# Bulk sync (existing)
+bun run sync_telegram.ts
+
+# List topics
+bun telegram/tg-topics.ts
+
+# Read last 20 messages from a topic
+bun telegram/tg-read.ts --topic "General" --limit 20
+
+# Read messages since a date
+bun telegram/tg-read.ts --topic "chat-yad" --since 2025-06-01
+
+# Send a message to a topic
+bun telegram/tg-send.ts --topic "agents" --message "Hello from agent"
+
+# Send multi-line via stdin
+echo "Summary of findings..." | bun telegram/tg-send.ts --topic "agents" --stdin
+
+# Send to default write topic (set TELEGRAM_WRITE_TOPIC in .env)
+bun telegram/tg-send.ts --message "Status update"
+```
+
+## Working Style
+
+- Iteration time must stay under 2 seconds (use `fast.py` for numpy speed)
+- Change one thing at a time (correctness, then speed, then energy)
+- Priority: correctness > wall-clock time > energy usage
+- One hypothesis per experiment, always compare against baseline
+- Record everything -- failed hypotheses are findings too
+- Apply anti-slop writing rules to all prose (no em dashes, no AI vocabulary)
+
+## Before Pushing
+
+- **Update `docs/changelog.md`** with what changed (bump version, add section)
+- **Sync Google Docs** if meeting notes may have changed: `python3 src/sync_google_docs.py`
+- **Sync Telegram** if group discussion may have new messages: `bun run sync_telegram.ts`
+- **Check `docs/index.md`** if findings or status changed -- homepage should reflect current state
+- **Check GitHub** for PRs/issues: `gh pr list --repo cybertronai/SutroYaro`
+
+Full sync workflow: [docs/tooling/sync-runbook.md](docs/tooling/sync-runbook.md)
+
+## People
+
+- **Yad** (repo creator, SutroYaro) — Built the Claude Code autonomous research lab, parallel agent experiments
+- **Yaroslav** (Sutro Group founder) — Technical sprints, algorithm work, cybertronai/sutro
+- **Emmett** — Aster agentic loop framework, 2x energy improvement on microgpt
+- **G B** — Architecture experiments (depth-1/hidden-64, ARD ~33-35)
+- **Germaine**, **Andy**, **Seth**, **Barak**, **Jamie Simon** — Group members
+
+## Contributing
+
+Multiple people contribute via PRs (fork and branch). See [CONTRIBUTING.md](CONTRIBUTING.md) for the full guide and [docs/branch-workflow.md](docs/branch-workflow.md) for branch naming, locked files, and agent permissions.
+
+- **`contributions/`** — Drop raw results here in any format. No template needed.
+- **`findings/_template.md`** — Standalone findings template for structured reports.
+- **`DISCOVERIES.md`** — Shared knowledge base. Anyone can PR new bullets.
+- **Metric isolation (LAB.md rule #9)** — Never modify tracker.py, cache_tracker.py, data.py, config.py, harness.py in experiment PRs.
+
+When reviewing PRs: check that results are reproducible, findings follow the template, and DISCOVERIES.md is updated if the experiment answers an open question.
+
+## Related Repos
+
+- https://github.com/cybertronai/sutro — Main code repo with sparse_parity_benchmark.py
+- https://github.com/cybertronai/SutroYaro — This research workspace

--- a/bin/review-cycle
+++ b/bin/review-cycle
@@ -1,0 +1,391 @@
+#!/usr/bin/env bash
+# Cross-model research review cycle.
+#
+# A supervisor agent reviews recent experiments, a researcher agent
+# responds, and the supervisor writes a final verdict. The dialogue
+# is file-mediated: each turn appends to research/reviews/{cycle-id}.md.
+# Any CLI tool can participate on either side.
+#
+# Usage:
+#   bin/review-cycle                                          # claude reviews last 5
+#   bin/review-cycle --tool codex --researcher-tool claude    # codex reviews claude's work
+#   bin/review-cycle --tool gemini --last 10 --turns 5       # gemini, more experiments, more turns
+#   bin/review-cycle --dry-run                                # print prompts, don't launch
+#
+# Prerequisites:
+#   - AI CLIs installed and authenticated (both supervisor and researcher tools)
+#   - research/log.jsonl has experiment entries
+#   - findings/ has corresponding findings docs
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO_ROOT"
+
+# --- Parse arguments ---
+
+SUPERVISOR_TOOL="claude"
+RESEARCHER_TOOL="claude"
+LAST_N=5
+MAX_TURNS=3
+RESEARCHER="yad-agent"
+CYCLE_ID=""
+DRY_RUN=false
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --tool)            SUPERVISOR_TOOL="$2"; shift 2 ;;
+        --researcher-tool) RESEARCHER_TOOL="$2"; shift 2 ;;
+        --last)            LAST_N="$2"; shift 2 ;;
+        --turns)           MAX_TURNS="$2"; shift 2 ;;
+        --researcher)      RESEARCHER="$2"; shift 2 ;;
+        --cycle-id)        CYCLE_ID="$2"; shift 2 ;;
+        --dry-run)         DRY_RUN=true; shift ;;
+        -h|--help)
+            echo "Usage: bin/review-cycle [OPTIONS]"
+            echo ""
+            echo "Cross-model review: a supervisor agent reviews experiments, the"
+            echo "researcher responds, and the supervisor writes a final verdict."
+            echo ""
+            echo "Options:"
+            echo "  --tool TOOL            Supervisor AI CLI (default: claude)"
+            echo "                           claude, codex, gemini, opencode, custom"
+            echo "  --researcher-tool TOOL Researcher AI CLI for response turns (default: claude)"
+            echo "  --last N               Review last N experiments (default: 5)"
+            echo "  --turns N              Max dialogue turns (default: 3)"
+            echo "  --researcher ID        Researcher identity (default: yad-agent)"
+            echo "  --cycle-id ID          Override auto-generated cycle ID"
+            echo "  --dry-run              Print prompts without launching agents"
+            echo ""
+            echo "Examples:"
+            echo "  bin/review-cycle --tool codex --researcher-tool claude --last 5"
+            echo "  bin/review-cycle --tool gemini --turns 5 --last 10"
+            echo "  bin/review-cycle --dry-run --last 3"
+            exit 0
+            ;;
+        *)  echo "Unknown option: $1"; exit 1 ;;
+    esac
+done
+
+# Auto-generate cycle ID
+if [ -z "$CYCLE_ID" ]; then
+    CYCLE_ID="review-$(date +%Y%m%d_%H%M%S)"
+fi
+
+REVIEW_DIR="research/reviews"
+REVIEW_FILE="${REVIEW_DIR}/${CYCLE_ID}.md"
+LEDGER="research/log.jsonl"
+
+# --- Agent dispatch (mirrors bin/run-agent) ---
+
+launch_agent() {
+    local tool="$1"
+    local prompt="$2"
+    local logfile="$3"
+
+    case "$tool" in
+        claude)
+            claude -p "$prompt" \
+                --allowedTools "Bash,Read,Write,Edit,Glob,Grep" \
+                --max-turns 50 \
+                2>&1 | tee "$logfile"
+            ;;
+        gemini)
+            gemini -p "$prompt" --yolo \
+                2>&1 | tee "$logfile"
+            ;;
+        codex)
+            codex -q "$prompt" \
+                2>&1 | tee "$logfile"
+            ;;
+        opencode)
+            opencode "$prompt" \
+                2>&1 | tee "$logfile"
+            ;;
+        *)
+            if [ -z "${AI_CMD:-}" ]; then
+                echo "ERROR: Unknown tool '$tool' and AI_CMD not set."
+                echo "Set AI_CMD to your AI CLI command."
+                exit 1
+            fi
+            echo "$prompt" | $AI_CMD 2>&1 | tee "$logfile"
+            ;;
+    esac
+}
+
+# --- Prompt builders ---
+
+build_supervisor_review_prompt() {
+    local turn_number="$1"
+
+    cat <<PROMPT_EOF
+You are a research supervisor for the SutroYaro sparse parity project.
+Your job is to review recent experiments for correctness, honest classification,
+and scientific rigor. You are reviewing work done by a research agent.
+
+## Project context
+
+Read DISCOVERIES.md to understand what has been proven and what is still open.
+Read AGENT.md for the experiment protocol the researcher followed.
+
+## Classification rules you are enforcing
+
+- WIN: primary metric improved over baseline
+- LOSS: experiment ran correctly, metric did not improve (valid negative result)
+- INVALID: crashed, no measurements, or harness corruption
+- INCONCLUSIVE: <2% delta, <10 samples, p>0.05, or hardware not stressed
+
+## Integrity rules
+
+- No inflation. If 6 data points, it says "6 data points."
+- Borderline p-values are not confident findings.
+- Hardware idle during measurement invalidates energy comparisons.
+- INCONCLUSIVE is not a FINDING. LOSS is not a "partial success."
+- No private conversation content or URLs in public files.
+
+## Your review checklist (from AGENTS.md)
+
+1. Check that results in log.jsonl match the findings doc
+2. Check DISCOVERIES.md for prior work on the same question
+3. Verify no locked files were modified (tracker.py, cache_tracker.py, data.py, config.py, harness.py)
+4. If an experiment answers an open question, verify DISCOVERIES.md was updated
+
+## Your task
+
+Review the last ${LAST_N} experiments in research/log.jsonl.
+For each experiment:
+1. Read the log entry (JSON line)
+2. Read the corresponding findings doc in findings/
+3. Cross-reference with DISCOVERIES.md for prior work
+4. Check if the classification is honest (does delta_pct direction match the class?)
+5. Check if the findings doc has all 6 required sections:
+   Question, What was performed, What was produced,
+   Can it be reproduced?, Finding, Files
+6. Check that "Can it be reproduced?" contains an actual executable command
+7. Check that the Finding section acknowledges sample size and limitations
+
+$(if [ "$turn_number" -gt 1 ]; then
+    echo "## Previous dialogue"
+    echo ""
+    echo "This is turn ${turn_number} of the review. Read the full dialogue so far"
+    echo "at: ${REVIEW_FILE}"
+    echo "The researcher has responded to your previous review."
+    echo "Address their responses. Where they fixed issues, acknowledge it."
+    echo "Where they dispute your findings, evaluate their evidence."
+fi)
+
+## Output
+
+$(if [ "$turn_number" -eq 1 ]; then
+    echo "Write your review to: ${REVIEW_FILE}"
+    echo "Start the file with this YAML front-matter:"
+    echo ""
+    echo "---"
+    echo "cycle_id: ${CYCLE_ID}"
+    echo "date: $(date +%Y-%m-%d)"
+    echo "supervisor_tool: ${SUPERVISOR_TOOL}"
+    echo "researcher_tool: ${RESEARCHER_TOOL}"
+    echo "experiments_reviewed: ${LAST_N}"
+    echo "max_turns: ${MAX_TURNS}"
+    echo "status: in_progress"
+    echo "---"
+    echo ""
+    echo "Then add a section: ## Supervisor Review (Turn 1)"
+else
+    echo "Append a new section to ${REVIEW_FILE}:"
+    echo "## Supervisor Review (Turn ${turn_number})"
+fi)
+
+For each experiment, include:
+- Experiment ID and title
+- Log class vs your assessment
+- Issues found (if any)
+- Verdict: CONFIRMED | RECLASSIFY | REVISION_NEEDED | FLAG
+
+End with a summary: counts of each verdict type.
+
+Start by reading: research/log.jsonl (last ${LAST_N} entries), DISCOVERIES.md, AGENT.md
+PROMPT_EOF
+}
+
+build_researcher_response_prompt() {
+    local turn_number="$1"
+
+    cat <<PROMPT_EOF
+You are a research agent for the SutroYaro sparse parity project.
+Your researcher ID is '${RESEARCHER}'.
+
+A supervisor has reviewed your recent experiments. Read the full review
+dialogue at: ${REVIEW_FILE}
+
+For each issue the supervisor raised:
+
+1. If the supervisor is correct:
+   - Acknowledge the error
+   - Fix it: update the findings doc in findings/, fix the classification
+     in research/log.jsonl, update DISCOVERIES.md if needed
+   - State what you changed
+
+2. If you disagree:
+   - Explain why with specific evidence (cite numbers, baselines, methodology)
+   - Do not defend incorrect classifications just to avoid admitting error
+
+3. If the supervisor flagged a missing section:
+   - Add it to the findings doc
+
+After addressing all issues, append your response to: ${REVIEW_FILE}
+Use the section header: ## Researcher Response (Turn ${turn_number})
+
+For each experiment the supervisor reviewed, state:
+- ACCEPTED: supervisor's verdict is correct, no changes needed
+- FIXED: you corrected the issue the supervisor identified (say what changed)
+- DISPUTED: you disagree with the supervisor (explain why with evidence)
+
+Be honest. If the supervisor caught a real error, say so.
+
+Start by reading: ${REVIEW_FILE}, then the relevant findings docs and log entries.
+PROMPT_EOF
+}
+
+build_supervisor_verdict_prompt() {
+    cat <<PROMPT_EOF
+You are a research supervisor for the SutroYaro sparse parity project.
+This is the final turn of a review dialogue.
+
+Read the full dialogue at: ${REVIEW_FILE}
+
+The researcher has responded to your review. Evaluate their responses and
+write a final verdict.
+
+Append to ${REVIEW_FILE} with section header: ## Final Verdict
+
+For each experiment, state:
+- APPROVED: experiment record is accurate (either originally or after correction)
+- CORRECTED: researcher fixed the issue you identified, now accurate
+- DISPUTED: disagreement remains -- flag for human review (explain the dispute)
+- REJECTED: classification or findings are materially wrong and were not fixed
+
+End with:
+1. A one-line summary (e.g., "4/5 approved, 1 corrected")
+2. Recommendations for the next research cycle (if any)
+3. Items requiring human attention (if any)
+PROMPT_EOF
+}
+
+# --- Safety checks ---
+
+if [ ! -f "$LEDGER" ]; then
+    echo "ERROR: No experiment log at $LEDGER."
+    echo "Run experiments first: bin/run-agent --tool claude --max 5"
+    exit 1
+fi
+
+ENTRY_COUNT=$(wc -l < "$LEDGER" | tr -d ' ')
+if [ "$ENTRY_COUNT" -eq 0 ]; then
+    echo "ERROR: $LEDGER is empty."
+    exit 1
+fi
+
+if [ "$ENTRY_COUNT" -lt "$LAST_N" ]; then
+    echo "WARNING: Log has $ENTRY_COUNT entries, reviewing all of them."
+    LAST_N="$ENTRY_COUNT"
+fi
+
+if [ "$MAX_TURNS" -lt 1 ]; then
+    echo "ERROR: --turns must be at least 1."
+    exit 1
+fi
+
+mkdir -p "$REVIEW_DIR"
+
+# --- Print configuration ---
+
+echo ""
+echo "=== Review Cycle: $CYCLE_ID ==="
+echo "Supervisor:  $SUPERVISOR_TOOL"
+echo "Researcher:  $RESEARCHER_TOOL (ID: $RESEARCHER)"
+echo "Experiments: last $LAST_N of $ENTRY_COUNT"
+echo "Max turns:   $MAX_TURNS"
+echo "Review file: $REVIEW_FILE"
+echo "Started:     $(date)"
+if [ "$DRY_RUN" = true ]; then
+    echo "Mode:        DRY RUN (prompts only)"
+fi
+echo ""
+
+# --- The dialogue loop ---
+
+for (( turn=1; turn<=MAX_TURNS; turn++ )); do
+    SESSION_LOG="research/.review-session-${CYCLE_ID}-turn${turn}.log"
+
+    # Determine role for this turn
+    if (( turn % 2 == 1 )); then
+        ROLE="Supervisor"
+        TOOL="$SUPERVISOR_TOOL"
+
+        if (( turn == MAX_TURNS )); then
+            # Last turn and it's the supervisor's: write verdict
+            PROMPT=$(build_supervisor_verdict_prompt)
+            echo "--- Turn $turn/$MAX_TURNS: $ROLE ($TOOL) — Final Verdict ---"
+        else
+            PROMPT=$(build_supervisor_review_prompt "$turn")
+            echo "--- Turn $turn/$MAX_TURNS: $ROLE ($TOOL) — Review ---"
+        fi
+    else
+        ROLE="Researcher"
+        TOOL="$RESEARCHER_TOOL"
+        PROMPT=$(build_researcher_response_prompt "$turn")
+        echo "--- Turn $turn/$MAX_TURNS: $ROLE ($TOOL) — Response ---"
+    fi
+
+    if [ "$DRY_RUN" = true ]; then
+        echo ""
+        echo "$PROMPT"
+        echo ""
+        echo "--- [DRY RUN: would launch $TOOL] ---"
+        echo ""
+        continue
+    fi
+
+    # Launch the agent
+    set +e
+    launch_agent "$TOOL" "$PROMPT" "$SESSION_LOG"
+    EXIT_CODE=$?
+    set -e
+
+    if [ $EXIT_CODE -ne 0 ]; then
+        echo "  Turn $turn exited with code $EXIT_CODE. Continuing."
+    fi
+
+    # Check if review file was created (turn 1) or exists (later turns)
+    if [ "$turn" -eq 1 ] && [ ! -f "$REVIEW_FILE" ]; then
+        echo "WARNING: Supervisor did not create $REVIEW_FILE. Continuing anyway."
+    fi
+
+    # Early exit: supervisor wrote final verdict before turn limit
+    if grep -q "## Final Verdict" "$REVIEW_FILE" 2>/dev/null; then
+        echo "  Final verdict found. Ending dialogue."
+        break
+    fi
+
+    # Brief pause between turns
+    if [ "$turn" -lt "$MAX_TURNS" ]; then
+        sleep 2
+    fi
+done
+
+# --- Finalize ---
+
+# Update status in YAML front-matter
+if [ -f "$REVIEW_FILE" ]; then
+    sed -i '' 's/status: in_progress/status: complete/' "$REVIEW_FILE" 2>/dev/null || \
+    sed -i 's/status: in_progress/status: complete/' "$REVIEW_FILE" 2>/dev/null || true
+fi
+
+echo ""
+echo "=== Review cycle complete ==="
+echo "Review file: $REVIEW_FILE"
+echo "Finished:    $(date)"
+echo ""
+echo "Read the dialogue:"
+echo "  cat $REVIEW_FILE"

--- a/docs/tooling/agent-cli-guide.md
+++ b/docs/tooling/agent-cli-guide.md
@@ -165,7 +165,34 @@ brew install --cask codex
 codex --version
 ```
 
-Included with ChatGPT Plus, Pro, Business, Edu, and Enterprise plans. Or use API credits.
+### Authentication (OAuth / ChatGPT subscription)
+
+Codex CLI supports two auth methods. **OAuth login is recommended** because it uses your existing ChatGPT subscription (Plus, Pro, Business, Edu, Enterprise) with no separate API billing.
+
+**Option 1: ChatGPT OAuth (recommended -- uses subscription, no API credits)**
+
+```bash
+codex --login
+```
+
+This opens a browser window for ChatGPT OAuth. Sign in with your ChatGPT account. The session token is stored locally. No API key needed, no usage charges beyond your subscription.
+
+The project's `.codex/config.toml` already sets `forced_login_method = "chatgpt"` so Codex will prefer OAuth by default in this repo.
+
+**Option 2: API key (pay-per-token)**
+
+```bash
+export OPENAI_API_KEY="sk-..."
+```
+
+Set the key in your shell profile or `.env`. This bills per token against your OpenAI API account. Use this if you don't have a ChatGPT subscription or need higher rate limits.
+
+**Verifying auth**:
+
+```bash
+codex --version   # should show version without auth errors
+codex "echo hello" # quick smoke test
+```
 
 ### Run experiments
 
@@ -181,9 +208,23 @@ bin/run-agent --tool codex --loop 10 --max 5
 
 The launcher calls `codex -q "$prompt"`. The `-q` flag runs in quiet/non-interactive mode.
 
+### Project config
+
+This repo includes Codex-specific configuration for feature parity with Claude Code:
+
+| File | Purpose | Claude Code equivalent |
+|------|---------|----------------------|
+| `.codex/config.toml` | Sandbox mode, approval policy, model, auth | `.claude/settings.local.json` |
+| `CODEX.md` | Project context (auto-loaded at session start) | `CLAUDE.md` |
+| `.codex/AGENTS.md` | Agent instructions: context loading, sync, writing rules | `.claude/skills/` |
+
+Codex auto-reads `CODEX.md` and `.codex/AGENTS.md` at session start, giving it the same project context, sync routines, and anti-slop writing rules that Claude Code gets from `CLAUDE.md` and `.claude/skills/`.
+
 ### Customization
 
-- **AGENTS.md**: Codex reads this file for project context (similar to CLAUDE.md for Claude Code)
+- **CODEX.md**: project context loaded at session start (same content as CLAUDE.md)
+- **.codex/AGENTS.md**: instructions for context loading, sync routine, writing rules
+- **.codex/config.toml**: sandbox mode, approval policy, model selection, auth method
 - **MCP servers**: supported for external tool integration
 - **Multi-agent**: experimental parallel agent support built in
 - **Sandbox**: cross-platform security (macOS Seatbelt, Linux Landlock)
@@ -272,6 +313,9 @@ bin/merge-findings research/log.jsonl --scoreboard
 | Looped overnight | Yes | Yes | Yes | Yes | No |
 | MCP servers | Yes | Yes | Yes | Yes | No |
 | Custom skills/plugins | Yes | Yes (extensions) | Yes | Yes | No |
+| Project context file | `CLAUDE.md` | `GEMINI.md` | `CODEX.md` | -- | -- |
+| Agent instructions | `.claude/skills/` | `.gemini/` | `.codex/AGENTS.md` | -- | -- |
+| OAuth (subscription) | Yes | Yes (Google) | Yes (ChatGPT) | No | Yes (Google) |
 | Multi-provider | No (Anthropic) | No (Google) | No (OpenAI) | Yes (75+) | Yes |
 | Context window | 200K (Opus: 1M) | 1M | Varies | Varies | Varies |
 | Cost | Subscription or API | Free tier | ChatGPT Plus or API | BYO API key | Free preview |

--- a/docs/tooling/agent-cli-guide.md
+++ b/docs/tooling/agent-cli-guide.md
@@ -304,6 +304,61 @@ bin/analyze-log --plot
 bin/merge-findings research/log.jsonl --scoreboard
 ```
 
+---
+
+## Cross-Model Supervision
+
+Use `bin/review-cycle` to have one AI model review experiments done by another. The supervisor and researcher engage in a multi-turn dialogue: the supervisor identifies issues, the researcher responds (fixing or disputing), and the supervisor writes a final verdict.
+
+### Why cross-model?
+
+Different models have different strengths. A research agent optimized for code execution (Claude, Codex) may miss classification errors that a reasoning-focused reviewer catches. Cross-model review reduces blind spots.
+
+### Usage
+
+```bash
+# Codex reviews Claude's last 5 experiments (3-turn dialogue)
+bin/review-cycle --tool codex --researcher-tool claude --last 5
+
+# Gemini reviews with more dialogue turns
+bin/review-cycle --tool gemini --researcher-tool claude --last 10 --turns 5
+
+# Same model can review itself (less diverse but still useful)
+bin/review-cycle --tool claude --researcher-tool claude --last 5
+
+# Preview the prompts without launching agents
+bin/review-cycle --dry-run --last 3
+```
+
+### How it works
+
+The dialogue has 3 turns by default (configurable with `--turns`):
+
+1. **Supervisor reviews** (Turn 1): reads `log.jsonl` entries and findings docs, checks classifications against integrity rules, assigns per-experiment verdicts (CONFIRMED, RECLASSIFY, REVISION_NEEDED, FLAG)
+2. **Researcher responds** (Turn 2): reads the review, fixes acknowledged errors in the actual files, or disputes with evidence
+3. **Supervisor verdict** (Turn 3): evaluates the responses, writes final status per experiment (APPROVED, CORRECTED, DISPUTED, REJECTED)
+
+Each turn is a separate CLI invocation. The dialogue accumulates in `research/reviews/{cycle-id}.md`, which serves as both the conversation medium and the permanent audit trail.
+
+### What the supervisor checks
+
+- Classification honesty: does `delta_pct` direction match the `class`?
+- Findings completeness: all 6 required sections present?
+- Reproducibility: "Can it be reproduced?" has executable commands?
+- Sample size: claims qualified by data point count?
+- Prior work: DISCOVERIES.md checked for duplicates?
+- Locked files: harness.py and measurement code unmodified?
+
+### Review file output
+
+Each review cycle produces `research/reviews/review-{timestamp}.md` with YAML front-matter and the full dialogue. Example summary:
+
+```
+Summary: 3/5 approved, 1/5 corrected, 1/5 disputed (needs human review)
+```
+
+Experiments marked DISPUTED are flagged for human attention.
+
 ## Comparing tools
 
 | Feature | Claude Code | Gemini CLI | Codex CLI | OpenCode | Antigravity |


### PR DESCRIPTION
## Summary

- Adds `bin/review-cycle`, a standalone script that lets one AI model supervise experiments done by another through a multi-turn dialogue
- Supervisor and researcher alternate turns via a shared review file — works with any CLI tool (Claude, Codex, Gemini, OpenCode)
- Follows `bin/run-agent` patterns exactly: same dispatch, same tool flags, same resilience

### How it works

```bash
# Codex reviews Claude's last 5 experiments
bin/review-cycle --tool codex --researcher-tool claude --last 5
```

**Turn 1 — Supervisor reviews**: reads `log.jsonl` + findings docs, checks classifications against integrity rules, assigns per-experiment verdicts (CONFIRMED / RECLASSIFY / REVISION_NEEDED / FLAG)

**Turn 2 — Researcher responds**: reads the review, fixes acknowledged errors in the actual files (findings docs, log entries), or disputes with evidence

**Turn 3 — Supervisor verdict**: evaluates responses, writes final status (APPROVED / CORRECTED / DISPUTED / REJECTED)

The dialogue accumulates in `research/reviews/{cycle-id}.md` — both the conversation medium and the permanent audit trail.

### What the supervisor checks

- Classification honesty: does `delta_pct` direction match the `class`?
- Findings completeness: all 6 required sections present?
- Reproducibility: "Can it be reproduced?" has executable commands?
- Sample size: claims qualified by data point count?
- Prior work: DISCOVERIES.md checked for duplicates?
- Locked files: harness.py and measurement code unmodified?

### Options

| Flag | Default | Description |
|------|---------|-------------|
| `--tool` | claude | Supervisor CLI |
| `--researcher-tool` | claude | Researcher CLI for response turns |
| `--last N` | 5 | Review last N experiments |
| `--turns N` | 3 | Max dialogue turns |
| `--dry-run` | — | Print prompts without launching agents |

## Test plan

- [ ] `bin/review-cycle --help` shows usage
- [ ] `bin/review-cycle --dry-run --last 3` prints 3 prompts (supervisor, researcher, verdict)
- [ ] `bin/review-cycle --tool claude --last 3` produces `research/reviews/review-*.md` with dialogue
- [ ] `bin/review-cycle --tool codex --researcher-tool claude` — cross-model dialogue works
- [ ] Review file has YAML front-matter with `status: complete` after run
- [ ] Researcher response turn can modify findings docs (fix issues supervisor flagged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)