### PR TITLE
docs: sops-nix Telegram credentials + flake shellHook

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,7 +133,8 @@ Other coding agents (Gemini, Codex) don't run the hooks but can read the rules a
 ```bash
 # First time: install deps and authenticate
 bun install
-cp .env.example .env  # fill in TELEGRAM_API_ID and TELEGRAM_API_HASH
+# On NixOS: credentials come from sops-nix via flake shellHook, no .env needed
+# On other systems: cp .env.example .env and fill in credentials
 tg auth login
 
 # Sync messages to SQLite (incremental)

--- a/docs/tooling/telegram-setup.md
+++ b/docs/tooling/telegram-setup.md
@@ -2,6 +2,39 @@
 
 Connect your agent to the Sutro Group Telegram. Two paths: read (sync messages to local SQLite) and write (post via your own bot).
 
+## Credentials
+
+### NixOS hosts (sops-nix, no .env needed)
+
+On the NixOS host, Telegram credentials are managed declaratively via sops-nix. Four secrets are encrypted in the NixOS config and decrypted to `/run/secrets/` at boot:
+
+| sops secret name | Environment variable | Purpose |
+|---|---|---|
+| `telegram_api_id` | `TELEGRAM_API_ID` | MTProto API ID (numeric) |
+| `telegram_api_hash` | `TELEGRAM_API_HASH` | MTProto API hash (hex string) |
+| `telegram_bot_token` | `TELEGRAM_BOT_TOKEN` | Bot token for posting |
+| `sutro_group_chat_id` | `SUTRO_GROUP_CHAT_ID` | Supergroup chat ID (negative number) |
+
+The project's `flake.nix` shellHook reads from `/run/secrets/` and exports these as environment variables. With `direnv` enabled (`.envrc` contains `use flake`), entering the project directory automatically loads them into memory. No `.env` file needed.
+
+Verify they're loaded:
+
+```bash
+echo $TELEGRAM_API_ID
+# Should print your numeric API ID, not empty
+```
+
+To add a new secret: encrypt it with sops in the NixOS repo (`~/dev/nixos/secrets/secrets.yaml`), declare it in the NixOS config (`sops.secrets.<name>`), and reference it in the `flake.nix` shellHook.
+
+### Non-NixOS hosts
+
+Copy `.env.example` to `.env` and fill in the values manually. The `.env` file is gitignored.
+
+```bash
+cp .env.example .env
+# Edit .env with your credentials
+```
+
 ## Reading: sync messages locally
 
 ### Quick path (no credentials)
@@ -23,12 +56,13 @@ The SQLite path is better for agents -- queryable, incremental, works offline af
 
 Go to [my.telegram.org/apps](https://my.telegram.org/apps) and create an application. You need the **API ID** (numeric) and **API Hash** (hex string).
 
-If you're using Claude Code with Chrome (`claude --chrome` or `/chrome`), the agent can open the browser and walk you through this interactively since it shares your login state.
-
 #### 2. Set up environment
 
+**NixOS**: Credentials are loaded automatically from sops-nix (see Credentials section above). Skip this step.
+
+**Other systems**: Create a `.env` file with your credentials:
+
 ```bash
-cd SutroYaro
 cp .env.example .env
 # Edit .env and fill in:
 #   TELEGRAM_API_ID=12345678
@@ -151,7 +185,9 @@ Ask the group admin to add your bot to the Sutro group.
 
 ### 3. Set up environment
 
-Add to your `.env`:
+**NixOS**: The bot token and chat ID are loaded from sops-nix automatically (see Credentials section). Skip this step.
+
+**Other systems**: Add to your `.env`:
 
 ```bash
 TELEGRAM_BOT_TOKEN=4839574812:AAFD39kkdpWt3ywyRZergyOLMaJhac60qc
@@ -203,7 +239,7 @@ The sync script uses a user account, so it captures all messages including bot p
 
 ## Troubleshooting
 
-**"Set TELEGRAM_API_ID and TELEGRAM_API_HASH in .env"**: You need credentials from [my.telegram.org/apps](https://my.telegram.org/apps). Use `claude --chrome` for guided setup.
+**"Set TELEGRAM_API_ID and TELEGRAM_API_HASH in .env"**: On NixOS, check that sops-nix decrypted the secrets: `ls /run/secrets/telegram_api_id`. On other systems, create `.env` from `.env.example` with credentials from [my.telegram.org/apps](https://my.telegram.org/apps).
 
 **"Session not found"**: Run `tg auth login` to authenticate. This is a one-time step.
 

--- a/flake.nix
+++ b/flake.nix
@@ -33,6 +33,13 @@
             ];
             shellHook = ''
               export PYTHONPATH=$PWD/src:$PYTHONPATH
+
+              # Load Telegram credentials from sops-nix secrets
+              for var in telegram_api_id telegram_api_hash telegram_bot_token sutro_group_chat_id; do
+                if [ -f "/run/secrets/$var" ]; then
+                  export "$(echo "$var" | tr '[:lower:]' '[:upper:]')"="$(cat "/run/secrets/$var")"
+                fi
+              done
             '';
           };
         });


### PR DESCRIPTION
## Summary
- Add sops-nix credential documentation to `docs/tooling/telegram-setup.md` (secret names, env vars, verification, how to add new secrets)
- Wire `flake.nix` shellHook to read from `/run/secrets/` and export `TELEGRAM_API_ID`, `TELEGRAM_API_HASH`, `TELEGRAM_BOT_TOKEN`, `SUTRO_GROUP_CHAT_ID`
- Update `CLAUDE.md` quick reference to mention both NixOS and non-NixOS paths
- All non-NixOS instructions (`.env` file) preserved unchanged

## Test plan
- [ ] On NixOS with sops-nix: `cd ~/dev/sutro-yaro && echo $TELEGRAM_API_ID` shows value
- [ ] On non-NixOS: `cp .env.example .env` workflow still documented and correct
- [ ] `bin/tg-sync` works after credentials are loaded