### PR TITLE
Add Sparse Parity Challenge references and docs page

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -189,3 +189,4 @@ When reviewing PRs: check that results are reproducible, findings follow the tem
 
 - https://github.com/cybertronai/sutro — Main code repo with sparse_parity_benchmark.py
 - https://github.com/cybertronai/SutroYaro — This research workspace
+- https://github.com/cybertronai/sparse-parity-challenge — Submission pipeline: submit a solve() function via GitHub Issue, auto-evaluated with TrackedArray

--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ A structured workspace where multiple people use different AI tools (Claude Code
 
 Current challenge: **sparse parity** (learn XOR/parity from random {-1,+1} inputs), plus sparse sum and sparse AND.
 
+[![Submit Solution](https://img.shields.io/badge/Submit_a_Solution-blue?style=for-the-badge)](https://github.com/cybertronai/sparse-parity-challenge/issues/new?template=submission.yml)
+
 ## Results So Far
 
 36 experiments across 3 challenges. Energy metric: DMD (Data Movement Distance, Ding et al. [arXiv:2312.14441](https://arxiv.org/abs/2312.14441)), auto-measured via [TrackedArray](https://cybertronai.github.io/SutroYaro/research/tracked-numpy/).

--- a/docs/index.md
+++ b/docs/index.md
@@ -82,6 +82,7 @@ Full setup instructions in [CONTRIBUTING.md](https://github.com/cybertronai/Sutr
 | Meeting notes and Google Docs | [Meetings](meetings/index.md) |
 | Auto DMD tracking | [Auto-instrumented DMD Tracking](research/tracked-numpy.md) |
 | How to contribute | [CONTRIBUTING.md](https://github.com/cybertronai/SutroYaro/blob/main/CONTRIBUTING.md) |
+| **Submit a solution** | [Sparse Parity Challenge](https://github.com/cybertronai/sparse-parity-challenge) |
 
 ## Quick Links
 
@@ -89,5 +90,6 @@ Full setup instructions in [CONTRIBUTING.md](https://github.com/cybertronai/Sutr
 |----------|------|
 | Telegram | [t.me/sutro_group](https://t.me/sutro_group) |
 | Code repo | [cybertronai/sutro](https://github.com/cybertronai/sutro) |
+| Challenge | [sparse-parity-challenge](https://github.com/cybertronai/sparse-parity-challenge) |
 | The Bigger Picture | [Yaroslav's roadmap](google-docs/bigger-picture.md) |
 | Meetings | Mondays 18:00 at South Park Commons (380 Brannan St) |

--- a/docs/research/sparse-parity-challenge.md
+++ b/docs/research/sparse-parity-challenge.md
@@ -1,0 +1,63 @@
+# Sparse Parity Challenge
+
+Submit a Python function that solves sparse parity. Your solution is automatically evaluated for accuracy, speed, and energy cost (DMC).
+
+[![Submit Solution](https://img.shields.io/badge/Submit-Solution-blue?style=for-the-badge)](https://github.com/cybertronai/sparse-parity-challenge/issues/new?template=submission.yml)
+
+## The problem
+
+Given `x` (n random {-1,+1} inputs) and `y` (product of k secret bits), find the k secret bit indices. Default: n=20 bits, k=3 secret, 17 noise.
+
+## How it works
+
+1. Click "Submit Solution" above (opens a GitHub Issue form)
+2. Paste your `solve()` function
+3. GitHub Actions runs it with TrackedArray (auto-measures memory access)
+4. Bot posts results: accuracy, DMC, wall time
+5. If accuracy >= 95%: a PR is opened to update the leaderboard
+6. Maintainer merges, leaderboard updates
+
+## Function signature
+
+```python
+def solve(x, y, n_bits, k_sparse):
+    """
+    Args:
+        x: numpy array (n_samples, n_bits), values in {-1, +1}
+        y: numpy array (n_samples,), values in {-1, +1}
+        n_bits: int, total number of bits
+        k_sparse: int, number of secret bits
+    Returns:
+        list[int]: sorted indices of the k secret bits
+    """
+```
+
+Only `numpy` allowed. 60-second timeout. Runs across 3 random seeds.
+
+## What we measure
+
+**DMC (Data Movement Complexity)**: how much energy your solution costs. Every numpy operation on your arrays is automatically tracked via TrackedArray. Each array read has a cost based on its reuse distance (how long ago the data was last written). Lower DMC = data stays in cache = less energy.
+
+The neural network baseline (SGD) has DMC ~1.3M. The best algebraic solver (GF(2)) has DMC ~13.5M but solves in 509 microseconds. Can you find a better tradeoff?
+
+## Leaderboard
+
+See the [live leaderboard](https://github.com/cybertronai/sparse-parity-challenge#leaderboard) on the challenge repo.
+
+## What doesn't work (save yourself time)
+
+From 36 experiments in the [research repo](https://github.com/cybertronai/SutroYaro):
+
+- **First-order correlations**: `E[x_i * y] = 0` for ALL bits, even secret ones. Parity has zero first-order signal.
+- **Pairwise correlations**: `E[x_i * x_j * y] = 0` for ALL pairs. You must test the full k-way interaction.
+- **Local learning rules**: Hebbian, Predictive Coding, Equilibrium Propagation, Target Propagation all fail at chance level.
+- **Greedy feature selection**: forward selection fails because there's no single bit that's informative alone.
+
+What works: algebraic methods (GF(2), KM influence), exhaustive search (Fourier), constraint satisfaction (SMT), and neural networks (SGD, but slow).
+
+## Links
+
+- [Challenge repo](https://github.com/cybertronai/sparse-parity-challenge) -- submissions, leaderboard, evaluation code
+- [Research repo](https://github.com/cybertronai/SutroYaro) -- 36 experiments, findings, TrackedArray source
+- [Practitioner's Field Guide](survey.md) -- ranked comparison of all methods
+- [TrackedArray docs](tracked-numpy.md) -- how DMC measurement works

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -92,6 +92,7 @@ nav:
       - Adding an Eval Challenge: research/adding-an-eval-challenge.md
       - Literature Review: research/sparse-parity-literature.md
       - Proposed Approaches: research/proposed-approaches.md
+      - Sparse Parity Challenge: research/sparse-parity-challenge.md
       - Survey: research/survey.md
       - Findings:
           # --- Mar 22 ---


### PR DESCRIPTION
## Summary

Adds references to the [sparse-parity-challenge](https://github.com/cybertronai/sparse-parity-challenge) repo across the docs and README. The challenge repo is a separate submission pipeline where anyone can paste a solve() function and get it auto-evaluated.

### Changes

- **CLAUDE.md**: Added challenge repo to Related Repos
- **README.md**: Submit button badge linking to the challenge form
- **docs/index.md**: "Submit a solution" in Where to Find Things + Quick Links
- **docs/research/sparse-parity-challenge.md**: New page explaining the challenge, function signature, what we measure, what doesn't work, links
- **mkdocs.yml**: Added challenge page to Research nav

5 files, +69 lines, no deletions to existing content.

---
_agent-0bserver07 (Claude Code) on behalf of Yad_