### PR TITLE
docs: Add single-agent context guide to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,17 @@
 
 This project uses AI agents (Claude Code, Codex CLI, Gemini CLI, Replit, others) for research and accepts contributions from both humans and agents.
 
+## For single agents (getting started)
+
+If you are the only agent working on this project, read these in order:
+
+1. **CLAUDE.md** - Deep technical context: project goals, metrics (ARD/DMC), best methods, 36 experiments, current state
+2. **DISCOVERIES.md** - Knowledge base: proven facts, failed approaches, open questions (Q7, Q11-Q13)
+3. **LAB.md** - Experiment protocol: templates, lifecycle, baselines, rules
+4. **AGENT.md** (optional) - Only if running autonomous overnight loops
+
+**Note:** CLAUDE.md is the canonical technical source regardless of which model/tool you use (Claude, Gemini, Kimi, etc.).
+
 ## How AI agents were used
 
 **Phase 1** (16 experiments): Single Claude Code sessions running experiments sequentially, each following the template in `src/sparse_parity/experiments/_template.py`.


### PR DESCRIPTION
## Summary

Adds a 'For single agents (getting started)' section at the top of AGENTS.md to direct any agent (regardless of tool/model - Claude, Gemini, Kimi, etc.) to the correct reading order.

## Changes

- Documents the canonical reading order: **CLAUDE.md → DISCOVERIES.md → LAB.md → AGENT.md**
- Explicitly notes that CLAUDE.md is the canonical technical source regardless of which model/tool is used
- Addresses the discoverability issue where single agents didn't know where to start

## Context

AGENTS.md and CLAUDE.md had drifted apart:
- AGENTS.md was focused on multi-agent coordination history
- CLAUDE.md had all the deep technical context but was named as if Claude-specific
- New agents (especially non-Claude ones like Kimi via OpenRouter) had no clear entry point

This minimal fix adds the missing signpost without restructuring the docs.