### PR TITLE
Add sqlite to devShell for telegram.db queries

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -32,6 +32,8 @@
               pkgs.bun
               # Google Docs sync
               pkgs.pandoc
+              # Ad-hoc queries against telegram.db and other SQLite state
+              pkgs.sqlite
             ];
             shellHook = ''
               export PYTHONPATH=$PWD/src:$PYTHONPATH


### PR DESCRIPTION
## Summary

Adds `pkgs.sqlite` to the nix devShell so the `sqlite3` CLI is available for ad-hoc queries.

**Why:** Several workflows touch `telegram.db`:
- `sutro-sync` / `weekly-catchup` / `prepare-meeting` skills
- Agent-driven introspection during reviews (e.g. "what's the latest group chatter on PR #X")

Python's built-in `sqlite3` module works but needs ~8 lines of boilerplate for a one-line SELECT. The CLI is much faster for throwaway queries.

**Cost:** ~5MB download added to first `nix develop` build. Already closure-adjacent to other tools; marginal impact.

## Test plan

- [ ] `nix develop --command command -v sqlite3` returns a nix-store path
- [ ] `nix develop --command sqlite3 telegram.db 'SELECT COUNT(*) FROM messages'` works

🤖 Generated with [Claude Code](https://claude.com/claude-code)