### PR TITLE
diagrams: single source of truth + bin/regen-diagrams + CI staleness check

### DIFF
--- a/.github/workflows/diagram-staleness.yml
+++ b/.github/workflows/diagram-staleness.yml
@@ -1,0 +1,40 @@
+name: Diagram staleness check
+
+# Fails any PR where docs/research/repo-tree.md or repo-layout.md have
+# drifted from a fresh regen of docs/research/_diagrams.yaml. The fix is
+# to run `bin/regen-diagrams` locally and commit the result.
+
+on:
+  pull_request:
+    paths:
+      - "docs/research/_diagrams.yaml"
+      - "docs/research/repo-tree.md"
+      - "docs/research/repo-layout.md"
+      - "bin/regen-diagrams"
+      - ".github/workflows/diagram-staleness.yml"
+  push:
+    branches: [main]
+    paths:
+      - "docs/research/_diagrams.yaml"
+      - "docs/research/repo-tree.md"
+      - "docs/research/repo-layout.md"
+      - "bin/regen-diagrams"
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install PyYAML
+        run: pip install pyyaml
+
+      - name: Verify diagrams match a fresh regen
+        run: |
+          bin/regen-diagrams --check
+          echo "✓ docs/research/repo-tree.md and repo-layout.md are in sync with _diagrams.yaml"

--- a/bin/regen-diagrams
+++ b/bin/regen-diagrams
@@ -1,0 +1,246 @@
+#!/usr/bin/env python3
+"""
+Regenerate the auto-managed diagram blocks in:
+
+- docs/research/repo-tree.md   (D3 interactive tree, treeData object)
+- docs/research/repo-layout.md (Mermaid graph, subgraphs + edges)
+
+Source of truth: docs/research/_diagrams.yaml.
+
+Run after editing the YAML, or after structural repo changes that should
+be reflected in the labels (new top-level dirs, renamed packages, etc.).
+
+Usage:
+    bin/regen-diagrams              # rewrite both target files
+    bin/regen-diagrams --check      # exit non-zero if rewrite would change anything
+                                    # (used by CI to catch stale diagrams)
+
+Idempotence: running twice with no edits in between produces no diff.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+try:
+    import yaml  # PyYAML
+except ImportError:
+    sys.stderr.write(
+        "regen-diagrams: PyYAML required. Install with `pip install pyyaml` "
+        "or run inside the Nix devShell.\n"
+    )
+    sys.exit(2)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+YAML_PATH = REPO_ROOT / "docs" / "research" / "_diagrams.yaml"
+TREE_MD_PATH = REPO_ROOT / "docs" / "research" / "repo-tree.md"
+LAYOUT_MD_PATH = REPO_ROOT / "docs" / "research" / "repo-layout.md"
+
+TREE_BEGIN = "// BEGIN_AUTOGEN treeData (regenerate via bin/regen-diagrams)"
+TREE_END = "// END_AUTOGEN treeData"
+LAYOUT_BEGIN = "<!-- BEGIN_AUTOGEN mermaidLayout (regenerate via bin/regen-diagrams) -->"
+LAYOUT_END = "<!-- END_AUTOGEN mermaidLayout -->"
+
+
+# ---------------------------------------------------------------------------
+# Auto-counts
+# ---------------------------------------------------------------------------
+
+def _count_glob(pattern: str) -> int:
+    """Count files matched by a glob, relative to the repo root."""
+    matches = list(REPO_ROOT.glob(pattern))
+    return sum(1 for m in matches if m.is_file())
+
+
+def _count_lines(rel_path: str) -> int:
+    """Count non-empty lines of a file relative to the repo root."""
+    p = REPO_ROOT / rel_path
+    if not p.exists():
+        return 0
+    with p.open("r", encoding="utf-8", errors="replace") as f:
+        return sum(1 for line in f if line.strip())
+
+
+def compute_auto_counts(spec: dict) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for name, cfg in (spec.get("auto_counts") or {}).items():
+        if "glob" in cfg:
+            counts[name] = _count_glob(cfg["glob"])
+        elif cfg.get("type") == "lines":
+            counts[name] = _count_lines(cfg["file"])
+        else:
+            sys.stderr.write(f"regen-diagrams: unknown auto_count config for {name}\n")
+            sys.exit(2)
+    return counts
+
+
+def interpolate(s: str, counts: dict[str, int]) -> str:
+    """Replace {placeholder} occurrences with corresponding count values."""
+    out = s
+    for k, v in counts.items():
+        out = out.replace("{" + k + "}", str(v))
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Tree (D3) builder
+# ---------------------------------------------------------------------------
+
+def _normalize_tree_node(node, counts: dict[str, int]) -> dict:
+    """A node is either a bare string (leaf) or a dict {name, children?}."""
+    if isinstance(node, str):
+        return {"name": interpolate(node, counts)}
+    if not isinstance(node, dict):
+        raise TypeError(f"tree node must be str or dict, got {type(node).__name__}")
+    out: dict = {"name": interpolate(node["name"], counts)}
+    if "children" in node and node["children"]:
+        out["children"] = [_normalize_tree_node(c, counts) for c in node["children"]]
+    return out
+
+
+def build_tree_data(spec: dict, counts: dict[str, int]) -> dict:
+    tree_spec = spec["tree"]
+    return {
+        "name": tree_spec["root"],
+        "children": [_normalize_tree_node(g, counts) for g in tree_spec["groups"]],
+    }
+
+
+def render_tree_block(tree_data: dict) -> str:
+    """Render the JS object literal that goes between the AUTOGEN markers."""
+    pretty = json.dumps(tree_data, indent=2, ensure_ascii=False)
+    return f"  const treeData = {pretty};"
+
+
+# ---------------------------------------------------------------------------
+# Mermaid (layout) builder
+# ---------------------------------------------------------------------------
+
+def _esc_label(label: str) -> str:
+    """Escape characters that confuse Mermaid node label parsing."""
+    return label.replace('"', '&quot;')
+
+
+def render_mermaid_block(spec: dict, counts: dict[str, int]) -> str:
+    layout = spec["layout"]
+    direction = layout.get("direction", "LR")
+    lines: list[str] = []
+    lines.append("```mermaid")
+    lines.append(f"graph {direction}")
+
+    for layer in layout["layers"]:
+        title = interpolate(layer["title"], counts)
+        lines.append(f'    subgraph {layer["id"]}["{_esc_label(title)}"]')
+        for node in layer["nodes"]:
+            label = interpolate(node["label"], counts)
+            lines.append(f'        {node["id"]}["{_esc_label(label)}"]')
+        lines.append("    end")
+        lines.append("")
+
+    for edge in layout["edges"]:
+        label = interpolate(edge["label"], counts)
+        lines.append(f'    {edge["from"]} -.{label}.-> {edge["to"]}')
+    lines.append("")
+
+    for layer in layout["layers"]:
+        lines.append(f'    style {layer["id"]} {layer["style"]}')
+
+    lines.append("```")
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Splice helpers
+# ---------------------------------------------------------------------------
+
+def splice(source: str, begin_marker: str, end_marker: str, replacement: str, file_label: str) -> str:
+    """Replace text between begin_marker and end_marker (exclusive of markers).
+
+    Indentation: keep whatever leading whitespace the BEGIN_marker line has,
+    apply it to the END_marker line too. The replacement is inserted as-is
+    on its own lines.
+    """
+    begin_idx = source.find(begin_marker)
+    end_idx = source.find(end_marker)
+    if begin_idx < 0 or end_idx < 0:
+        raise SystemExit(
+            f"regen-diagrams: missing AUTOGEN markers in {file_label}\n"
+            f"  expected: {begin_marker}\n"
+            f"            ...generated content...\n"
+            f"            {end_marker}"
+        )
+    if end_idx < begin_idx:
+        raise SystemExit(
+            f"regen-diagrams: AUTOGEN markers out of order in {file_label}"
+        )
+
+    # Find the newline at the end of the BEGIN marker line.
+    after_begin = source.find("\n", begin_idx)
+    if after_begin < 0:
+        raise SystemExit(f"regen-diagrams: BEGIN marker has no trailing newline in {file_label}")
+
+    # Find the start of the END marker line.
+    end_line_start = source.rfind("\n", 0, end_idx) + 1
+
+    return source[: after_begin + 1] + replacement + "\n" + source[end_line_start:]
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Exit non-zero if rewriting would change either target file (CI mode).",
+    )
+    args = parser.parse_args()
+
+    with YAML_PATH.open("r", encoding="utf-8") as f:
+        spec = yaml.safe_load(f)
+
+    counts = compute_auto_counts(spec)
+
+    tree_data = build_tree_data(spec, counts)
+    tree_block = render_tree_block(tree_data)
+    mermaid_block = render_mermaid_block(spec, counts)
+
+    targets = [
+        (TREE_MD_PATH, TREE_BEGIN, TREE_END, tree_block),
+        (LAYOUT_MD_PATH, LAYOUT_BEGIN, LAYOUT_END, mermaid_block),
+    ]
+
+    changed = False
+    for path, begin, end, replacement in targets:
+        original = path.read_text(encoding="utf-8")
+        rewritten = splice(original, begin, end, replacement, str(path.relative_to(REPO_ROOT)))
+        if rewritten != original:
+            changed = True
+            if args.check:
+                sys.stderr.write(
+                    f"regen-diagrams --check: {path.relative_to(REPO_ROOT)} is stale.\n"
+                    f"Run `bin/regen-diagrams` and commit the result.\n"
+                )
+            else:
+                path.write_text(rewritten, encoding="utf-8")
+                print(f"regen-diagrams: rewrote {path.relative_to(REPO_ROOT)}")
+        else:
+            if not args.check:
+                print(f"regen-diagrams: {path.relative_to(REPO_ROOT)} unchanged")
+
+    if args.check:
+        return 1 if changed else 0
+
+    print(f"regen-diagrams: counts → {counts}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/docs/research/_diagrams.yaml
+++ b/docs/research/_diagrams.yaml
@@ -1,0 +1,167 @@
+# Single source of truth for the auto-generated repo diagrams.
+#
+# Both `docs/research/repo-tree.md` (D3 interactive tree) and
+# `docs/research/repo-layout.md` (Mermaid box-and-arrow graph) are
+# regenerated from this file by `bin/regen-diagrams`.
+#
+# Edit this file → run `bin/regen-diagrams` → commit the changes.
+# CI will fail any PR where the generated files don't match a fresh regen
+# of this YAML.
+
+# Auto-counts: glob patterns whose match counts get interpolated below
+# wherever a placeholder like `{findings_count}` appears.
+auto_counts:
+  findings_count:
+    glob: "findings/exp_*.md"
+  experiments_jsonl_count:
+    file: "research/log.jsonl"
+    type: "lines"
+  task_count:
+    glob: "docs/tasks/[0-9]*-*.md"
+
+# ============================================================================
+# repo-tree.md (D3 interactive tree)
+# ============================================================================
+#
+# Top-level groups with explicit children. The generator emits this as a
+# JS object literal that the D3 hierarchy consumes.
+tree:
+  root: SutroYaro
+  groups:
+    - name: "Top-level docs"
+      children:
+        - "README.md"
+        - "CLAUDE.md"
+        - "LAB.md"
+        - "AGENT.md"
+        - "DISCOVERIES.md"
+        - "TODO.md"
+        - "CONTRIBUTING.md"
+        - "AGENTS.md"
+        - "CODEX.md"
+        - "GEMINI.md"
+        - "AGENT_EVAL.md"
+    - name: "src/"
+      children:
+        - "bytedmd/  (primary metric, vendored)"
+        - name: "sparse_parity/"
+          children:
+            - "harness.py"
+            - "tracker.py"
+            - "cache_tracker.py"
+            - "tracked_numpy.py"
+            - "train.py"
+            - "train_fused.py"
+            - "train_perlayer.py"
+            - "fast.py"
+            - "model.py"
+            - "data.py"
+            - "config.py"
+            - "eval/"
+            - "experiments/"
+            - "challenges/"
+            - "telegram_sync/"
+        - "telegram/"
+    - name: "bin/"
+      children:
+        - "reproduce-all"
+        - "run-agent"
+        - "analyze-log"
+        - "complexity-check"
+        - "score-all"
+        - "regen-diagrams"
+        - "tg-sync"
+        - "tg-post"
+        - "tg-auth"
+        - "merge-findings"
+    - name: "checks/"
+      children:
+        - "env_check.py"
+        - "baseline_check.py"
+    - name: "tests/"
+    - name: "research/"
+      children:
+        - "log.jsonl  ({experiments_jsonl_count} experiments)"
+        - "questions.yaml"
+        - "search_space.yaml"
+    - name: "findings/  ({findings_count} exp_*.md files)"
+    - name: "results/"
+    - name: "contributions/"
+    - name: "docs/  (mkdocs site)"
+      children:
+        - "index.md"
+        - "context.md"
+        - "changelog.md"
+        - "research/"
+        - "findings/"
+        - "catchups/"
+        - "meetings/"
+        - "google-docs/"
+        - "agent-prompts/"
+        - "tasks/  ({task_count} tasks)"
+        - "tooling/"
+        - "diagrams/"
+
+# ============================================================================
+# repo-layout.md (Mermaid box-and-arrow graph)
+# ============================================================================
+#
+# Five layers + edges between them. Each layer is rendered as a Mermaid
+# `subgraph`; each node becomes a node line; edges become `from -.label.-> to`.
+layout:
+  direction: LR
+  layers:
+    - id: DOCS
+      title: "Top-level Docs - read-first stack"
+      style: "fill:#fde7c4,stroke:#d4a85a,color:#000"
+      nodes:
+        - { id: README, label: "README.md" }
+        - { id: CLAUDE, label: "CLAUDE.md" }
+        - { id: LAB, label: "LAB.md" }
+        - { id: AGENT, label: "AGENT.md" }
+        - { id: DISC, label: "DISCOVERIES.md" }
+        - { id: TODO, label: "TODO.md" }
+        - { id: CONTRIB, label: "CONTRIBUTING.md" }
+        - { id: TOOLS, label: "AGENTS.md / CODEX.md / GEMINI.md / AGENT_EVAL.md" }
+    - id: CODE
+      title: "src/ - Code"
+      style: "fill:#c8e6c9,stroke:#4a8c4f,color:#000"
+      nodes:
+        - { id: BYTEDMD, label: "bytedmd/<br/>primary metric, vendored" }
+        - { id: SP, label: "sparse_parity/<br/>harness, tracker, training, eval, experiments, challenges" }
+        - { id: TG, label: "telegram/<br/>TS sync" }
+    - id: OPS
+      title: "Ops + Tests"
+      style: "fill:#dcedc8,stroke:#7a9a52,color:#000"
+      nodes:
+        - { id: BIN, label: "bin/<br/>reproduce-all, run-agent, tg-sync, regen-diagrams" }
+        - { id: CHECKS, label: "checks/<br/>env_check, baseline_check" }
+        - { id: TESTS, label: "tests/" }
+    - id: ARTIFACTS
+      title: "Research Artifacts"
+      style: "fill:#bbdefb,stroke:#4a7fb8,color:#000"
+      nodes:
+        - { id: RESEARCH, label: "research/<br/>log.jsonl ({experiments_jsonl_count} entries), questions.yaml, search_space.yaml" }
+        - { id: FINDINGS, label: "findings/<br/>{findings_count} per-experiment reports" }
+        - { id: RESULTS, label: "results/<br/>raw numeric outputs" }
+        - { id: CONTRIBDIR, label: "contributions/<br/>external drop-zone" }
+    - id: SITE
+      title: "docs/ - mkdocs site"
+      style: "fill:#e1bee7,stroke:#8e5ba0,color:#000"
+      nodes:
+        - { id: DRESEARCH, label: "research/<br/>findings, surveys, system overviews" }
+        - { id: DFINDINGS, label: "findings/<br/>per-experiment site pages" }
+        - { id: DCATCH, label: "catchups/<br/>weekly summaries" }
+        - { id: DMEET, label: "meetings/, meeting-notes/, lectures/" }
+        - { id: DGOOGLE, label: "google-docs/<br/>synced" }
+        - { id: DPROMPTS, label: "agent-prompts/" }
+        - { id: DTASKS, label: "tasks/<br/>{task_count} task specs + INDEX" }
+        - { id: DTOOL, label: "tooling/<br/>telegram, automation, agent compat" }
+        - { id: DDIAG, label: "diagrams/<br/>SVGs" }
+  edges:
+    - { from: CLAUDE, to: CODE, label: "points to" }
+    - { from: LAB, to: CODE, label: "governs" }
+    - { from: AGENT, to: ARTIFACTS, label: "drives" }
+    - { from: CODE, to: ARTIFACTS, label: "writes" }
+    - { from: ARTIFACTS, to: SITE, label: "published as" }
+    - { from: DOCS, to: SITE, label: "surfaced on" }

--- a/docs/research/repo-layout.md
+++ b/docs/research/repo-layout.md
@@ -9,48 +9,49 @@ The SutroYaro workspace splits into four layers: read-first docs that load agent
 <button data-mpz="reset" title="Reset zoom" style="width: 32px; height: 32px; border: 1px solid var(--md-default-fg-color--lightest); border-radius: 4px; background: var(--md-default-bg-color); color: var(--md-default-fg-color); cursor: pointer; font-size: 14px; line-height: 1;">⤾</button>
 </div>
 
+<!-- BEGIN_AUTOGEN mermaidLayout (regenerate via bin/regen-diagrams) -->
 ```mermaid
 graph LR
-    subgraph DOCS[Top-level Docs - read-first stack]
-        README[README.md]
-        CLAUDE[CLAUDE.md]
-        LAB[LAB.md]
-        AGENT[AGENT.md]
-        DISC[DISCOVERIES.md]
-        TODO[TODO.md]
-        CONTRIB[CONTRIBUTING.md]
-        TOOLS[AGENTS.md / CODEX.md / AGENT_EVAL.md]
+    subgraph DOCS["Top-level Docs - read-first stack"]
+        README["README.md"]
+        CLAUDE["CLAUDE.md"]
+        LAB["LAB.md"]
+        AGENT["AGENT.md"]
+        DISC["DISCOVERIES.md"]
+        TODO["TODO.md"]
+        CONTRIB["CONTRIBUTING.md"]
+        TOOLS["AGENTS.md / CODEX.md / GEMINI.md / AGENT_EVAL.md"]
     end
 
-    subgraph CODE[src/ - Code]
-        BYTEDMD[bytedmd/<br/>primary metric, vendored]
-        SP[sparse_parity/<br/>harness, tracker, training, eval, experiments]
-        TG[telegram/<br/>TS sync]
+    subgraph CODE["src/ - Code"]
+        BYTEDMD["bytedmd/<br/>primary metric, vendored"]
+        SP["sparse_parity/<br/>harness, tracker, training, eval, experiments, challenges"]
+        TG["telegram/<br/>TS sync"]
     end
 
-    subgraph OPS[Ops + Tests]
-        BIN[bin/<br/>reproduce-all, run-agent, tg-sync]
-        CHECKS[checks/<br/>env_check, baseline_check]
-        TESTS[tests/]
+    subgraph OPS["Ops + Tests"]
+        BIN["bin/<br/>reproduce-all, run-agent, tg-sync, regen-diagrams"]
+        CHECKS["checks/<br/>env_check, baseline_check"]
+        TESTS["tests/"]
     end
 
-    subgraph ARTIFACTS[Research Artifacts]
-        RESEARCH[research/<br/>log.jsonl, questions.yaml, search_space.yaml]
-        FINDINGS[findings/<br/>38 per-experiment reports]
-        RESULTS[results/<br/>raw numeric outputs]
-        CONTRIBDIR[contributions/<br/>external drop-zone]
+    subgraph ARTIFACTS["Research Artifacts"]
+        RESEARCH["research/<br/>log.jsonl (37 entries), questions.yaml, search_space.yaml"]
+        FINDINGS["findings/<br/>41 per-experiment reports"]
+        RESULTS["results/<br/>raw numeric outputs"]
+        CONTRIBDIR["contributions/<br/>external drop-zone"]
     end
 
-    subgraph SITE[docs/ - mkdocs site]
-        DRESEARCH[research/<br/>findings, surveys, system overviews]
-        DFINDINGS[findings/<br/>per-experiment site pages]
-        DCATCH[catchups/<br/>weekly summaries]
-        DMEET[meetings/, meeting-notes/, lectures/]
-        DGOOGLE[google-docs/<br/>synced]
-        DPROMPTS[agent-prompts/]
-        DTASKS[tasks/<br/>specs 1-10 + INDEX]
-        DTOOL[tooling/<br/>telegram, automation, agent compat]
-        DDIAG[diagrams/<br/>SVGs]
+    subgraph SITE["docs/ - mkdocs site"]
+        DRESEARCH["research/<br/>findings, surveys, system overviews"]
+        DFINDINGS["findings/<br/>per-experiment site pages"]
+        DCATCH["catchups/<br/>weekly summaries"]
+        DMEET["meetings/, meeting-notes/, lectures/"]
+        DGOOGLE["google-docs/<br/>synced"]
+        DPROMPTS["agent-prompts/"]
+        DTASKS["tasks/<br/>11 task specs + INDEX"]
+        DTOOL["tooling/<br/>telegram, automation, agent compat"]
+        DDIAG["diagrams/<br/>SVGs"]
     end
 
     CLAUDE -.points to.-> CODE
@@ -66,6 +67,7 @@ graph LR
     style ARTIFACTS fill:#bbdefb,stroke:#4a7fb8,color:#000
     style SITE fill:#e1bee7,stroke:#8e5ba0,color:#000
 ```
+<!-- END_AUTOGEN mermaidLayout -->
 
 </div>
 

--- a/docs/research/repo-tree.md
+++ b/docs/research/repo-tree.md
@@ -13,101 +13,225 @@ Click any node with children to expand or collapse it. Internal (directory-like)
 <script src="https://d3js.org/d3.v7.min.js"></script>
 <script>
 (function () {
-  // Hardcoded tree data for SutroYaro repo.
+  // BEGIN_AUTOGEN treeData (regenerate via bin/regen-diagrams)
   const treeData = {
-    name: "SutroYaro",
-    children: [
-      {
-        name: "Top-level docs",
-        children: [
-          { name: "README.md" },
-          { name: "CLAUDE.md" },
-          { name: "LAB.md" },
-          { name: "AGENT.md" },
-          { name: "DISCOVERIES.md" },
-          { name: "TODO.md" },
-          { name: "CONTRIBUTING.md" },
-          { name: "AGENTS.md" },
-          { name: "CODEX.md" },
-          { name: "AGENT_EVAL.md" }
-        ]
-      },
-      {
-        name: "src/",
-        children: [
-          { name: "bytedmd/  (primary metric, vendored)" },
-          {
-            name: "sparse_parity/",
-            children: [
-              { name: "harness.py" },
-              { name: "tracker.py" },
-              { name: "cache_tracker.py" },
-              { name: "tracked_numpy.py" },
-              { name: "train.py" },
-              { name: "train_fused.py" },
-              { name: "train_perlayer.py" },
-              { name: "fast.py" },
-              { name: "model.py" },
-              { name: "data.py" },
-              { name: "config.py" },
-              { name: "eval/" },
-              { name: "experiments/" },
-              { name: "telegram_sync/" }
-            ]
-          },
-          { name: "telegram/" }
-        ]
-      },
-      {
-        name: "bin/",
-        children: [
-          { name: "reproduce-all" },
-          { name: "run-agent" },
-          { name: "analyze-log" },
-          { name: "tg-sync" },
-          { name: "tg-post" },
-          { name: "tg-auth" },
-          { name: "merge-findings" }
-        ]
-      },
-      {
-        name: "checks/",
-        children: [
-          { name: "env_check.py" },
-          { name: "baseline_check.py" }
-        ]
-      },
-      { name: "tests/" },
-      {
-        name: "research/",
-        children: [
-          { name: "log.jsonl  (37 experiments)" },
-          { name: "questions.yaml" },
-          { name: "search_space.yaml" }
-        ]
-      },
-      { name: "findings/  (38 exp_*.md files)" },
-      { name: "results/" },
-      { name: "contributions/" },
-      {
-        name: "docs/  (mkdocs site)",
-        children: [
-          { name: "index.md" },
-          { name: "context.md" },
-          { name: "changelog.md" },
-          { name: "research/" },
-          { name: "findings/" },
-          { name: "catchups/" },
-          { name: "meetings/" },
-          { name: "google-docs/" },
-          { name: "agent-prompts/" },
-          { name: "tasks/" },
-          { name: "tooling/" },
-          { name: "diagrams/" }
-        ]
-      }
-    ]
-  };
+  "name": "SutroYaro",
+  "children": [
+    {
+      "name": "Top-level docs",
+      "children": [
+        {
+          "name": "README.md"
+        },
+        {
+          "name": "CLAUDE.md"
+        },
+        {
+          "name": "LAB.md"
+        },
+        {
+          "name": "AGENT.md"
+        },
+        {
+          "name": "DISCOVERIES.md"
+        },
+        {
+          "name": "TODO.md"
+        },
+        {
+          "name": "CONTRIBUTING.md"
+        },
+        {
+          "name": "AGENTS.md"
+        },
+        {
+          "name": "CODEX.md"
+        },
+        {
+          "name": "GEMINI.md"
+        },
+        {
+          "name": "AGENT_EVAL.md"
+        }
+      ]
+    },
+    {
+      "name": "src/",
+      "children": [
+        {
+          "name": "bytedmd/  (primary metric, vendored)"
+        },
+        {
+          "name": "sparse_parity/",
+          "children": [
+            {
+              "name": "harness.py"
+            },
+            {
+              "name": "tracker.py"
+            },
+            {
+              "name": "cache_tracker.py"
+            },
+            {
+              "name": "tracked_numpy.py"
+            },
+            {
+              "name": "train.py"
+            },
+            {
+              "name": "train_fused.py"
+            },
+            {
+              "name": "train_perlayer.py"
+            },
+            {
+              "name": "fast.py"
+            },
+            {
+              "name": "model.py"
+            },
+            {
+              "name": "data.py"
+            },
+            {
+              "name": "config.py"
+            },
+            {
+              "name": "eval/"
+            },
+            {
+              "name": "experiments/"
+            },
+            {
+              "name": "challenges/"
+            },
+            {
+              "name": "telegram_sync/"
+            }
+          ]
+        },
+        {
+          "name": "telegram/"
+        }
+      ]
+    },
+    {
+      "name": "bin/",
+      "children": [
+        {
+          "name": "reproduce-all"
+        },
+        {
+          "name": "run-agent"
+        },
+        {
+          "name": "analyze-log"
+        },
+        {
+          "name": "complexity-check"
+        },
+        {
+          "name": "score-all"
+        },
+        {
+          "name": "regen-diagrams"
+        },
+        {
+          "name": "tg-sync"
+        },
+        {
+          "name": "tg-post"
+        },
+        {
+          "name": "tg-auth"
+        },
+        {
+          "name": "merge-findings"
+        }
+      ]
+    },
+    {
+      "name": "checks/",
+      "children": [
+        {
+          "name": "env_check.py"
+        },
+        {
+          "name": "baseline_check.py"
+        }
+      ]
+    },
+    {
+      "name": "tests/"
+    },
+    {
+      "name": "research/",
+      "children": [
+        {
+          "name": "log.jsonl  (37 experiments)"
+        },
+        {
+          "name": "questions.yaml"
+        },
+        {
+          "name": "search_space.yaml"
+        }
+      ]
+    },
+    {
+      "name": "findings/  (41 exp_*.md files)"
+    },
+    {
+      "name": "results/"
+    },
+    {
+      "name": "contributions/"
+    },
+    {
+      "name": "docs/  (mkdocs site)",
+      "children": [
+        {
+          "name": "index.md"
+        },
+        {
+          "name": "context.md"
+        },
+        {
+          "name": "changelog.md"
+        },
+        {
+          "name": "research/"
+        },
+        {
+          "name": "findings/"
+        },
+        {
+          "name": "catchups/"
+        },
+        {
+          "name": "meetings/"
+        },
+        {
+          "name": "google-docs/"
+        },
+        {
+          "name": "agent-prompts/"
+        },
+        {
+          "name": "tasks/  (11 tasks)"
+        },
+        {
+          "name": "tooling/"
+        },
+        {
+          "name": "diagrams/"
+        }
+      ]
+    }
+  ]
+};
+  // END_AUTOGEN treeData
 
   function render() {
     const container = document.getElementById("tree-viz");


### PR DESCRIPTION
## Summary

Implements option (C) — full overhaul. Both repo diagrams now regenerate from a single YAML.

### What's new

- **`docs/research/_diagrams.yaml`** — single source of truth. Layer titles, node labels, edges, tree groups, auto-count placeholders.
- **`bin/regen-diagrams`** — Python generator. Reads YAML, computes auto-counts via globs, splices generated content between AUTOGEN markers in the two target files. Idempotent: running twice produces no diff. `--check` mode for CI.
- **`docs/research/repo-tree.md`** + **`repo-layout.md`** — pan/zoom + container HTML untouched. Only the data blocks live between markers and get rewritten.
- **`.github/workflows/diagram-staleness.yml`** — runs `bin/regen-diagrams --check` on PRs that touch the YAML or the generated files. Fails the build with a helpful "run `bin/regen-diagrams` locally and commit" message if regen would change anything.

### Drift caught on first regen
- `findings_count`: hardcoded **38** → actual **41** (auto-counted)
- `task_count`: hardcoded **"specs 1-10 + INDEX"** → actual **11** (auto-counted)
- Tree was missing `GEMINI.md` (added Apr 21 via PR #72)
- Tree was missing `challenges/` (added Apr 20 via PR #82)
- `bin/` was missing `complexity-check`, `score-all`, `regen-diagrams`

### What stayed untouched
- Pan/zoom controls (svg-pan-zoom + d3-zoom buttons)
- Container `<div>` and `<button>` HTML
- Prose, `## Notes` section, `!!! info` admonition

The generator never sees the JS/HTML — it only edits the marked data blocks.

### Workflow for editing the diagrams

1. Edit `docs/research/_diagrams.yaml`
2. Run `bin/regen-diagrams`
3. Commit both the YAML and the regenerated `.md` files

CI catches anyone who edits the YAML without running the regen.

## Test plan

- [x] `bin/regen-diagrams` runs clean (idempotent on second invocation)
- [x] `bin/regen-diagrams --check` exits 0 after a fresh regen
- [x] `python3 -m mkdocs build --strict` passes (no new warnings)
- [x] Drift detection works (caught 5 stale entries on first run)
- [ ] CI workflow passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)