### PR TITLE
docs: v0.29.0 changelog — auto-diagrams + CONTRIBUTING flows

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -137,7 +137,54 @@ Open questions live in [DISCOVERIES.md](DISCOVERIES.md) under "Open Questions." 
 - Describe what you tried and what happened
 - Someone (human or AI) will review and merge
 
-No CI gates. No test coverage requirements. The only hard rule is: don't break existing experiments.
+`main` is now branch-protected: PRs require **1 approval** before merge. Repo admins can override for hotfixes (`gh pr merge --admin`). Force-push and branch deletion are blocked.
+
+The only CI gate today: `diagram-staleness.yml` (see "Updating the repo diagrams" below). No test coverage requirements. Hard rule: don't break existing experiments.
+
+## Updating the repo diagrams
+
+The two diagrams on the docs site —
+[Repo Layout](https://cybertronai.github.io/SutroYaro/research/repo-layout/) (Mermaid)
+and [Interactive Repo Tree](https://cybertronai.github.io/SutroYaro/research/repo-tree/) (D3) —
+are generated from a single YAML.
+
+**Don't edit the `.md` files directly.** They have `BEGIN_AUTOGEN` / `END_AUTOGEN` markers around the data blocks; anything between is rewritten by the generator.
+
+```bash
+# 1. Edit the source of truth
+$EDITOR docs/research/_diagrams.yaml
+
+# 2. Regenerate both diagrams
+bin/regen-diagrams
+
+# 3. Commit YAML + regenerated .md files together
+git add docs/research/_diagrams.yaml docs/research/repo-{tree,layout}.md
+git commit -m "diagrams: ..."
+```
+
+CI (`diagram-staleness.yml`) fails any PR where the `.md` files have drifted from a fresh regen. The error message tells you to run `bin/regen-diagrams` locally and commit.
+
+**What's auto-counted** (don't hardcode these in the YAML):
+- `{findings_count}` — number of `findings/exp_*.md` files
+- `{experiments_jsonl_count}` — line count of `research/log.jsonl`
+- `{task_count}` — number of `docs/tasks/[0-9]*-*.md` files
+
+## Releases and version tags
+
+Versions are recorded in [`docs/changelog.md`](docs/changelog.md) following [Semantic Versioning](https://semver.org/) and the [Keep a Changelog](https://keepachangelog.com/) format.
+
+Each released version has a matching annotated git tag (`v0.29.0`, `v0.28.0`, etc.) pointing at the changelog commit that shipped it. Browse them via `git tag -l 'v*'` or on the [GitHub releases page](https://github.com/cybertronai/SutroYaro/releases).
+
+When you add a new release entry to `docs/changelog.md`, the workflow is:
+
+```bash
+# After the changelog PR merges to main
+git fetch origin --tags
+git tag -a v0.X.0 <merge-commit-sha> -m "v0.X.0"
+git push origin v0.X.0
+```
+
+Tag the **merge commit** that landed the changelog entry, not your feature branch.
 
 ## Questions
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -35,6 +35,26 @@ Answers Yaroslav's Apr 20 question: *how far are current solutions from the Byte
 
 Yellow `#FBCA04`, description "Spec posted, awaiting follow-up implementation." Applied to remaining open issues that have substantive specs but haven't been built yet: #5, #14, #54.
 
+### Auto-generated repo diagrams (PR #91)
+
+Both `docs/research/repo-tree.md` (D3 interactive tree) and `docs/research/repo-layout.md` (Mermaid graph) now regenerate from `docs/research/_diagrams.yaml` via [`bin/regen-diagrams`](https://github.com/cybertronai/SutroYaro/blob/main/bin/regen-diagrams). Pan/zoom HTML and JS are untouched — only the data blocks (between `BEGIN_AUTOGEN` / `END_AUTOGEN` markers) get rewritten.
+
+CI workflow [`diagram-staleness.yml`](https://github.com/cybertronai/SutroYaro/blob/main/.github/workflows/diagram-staleness.yml) runs `bin/regen-diagrams --check` on PRs that touch the YAML or generated files; fails the build if a regen would change anything, with the fix in the error message.
+
+**Drift caught on first regen:**
+- `findings_count`: hardcoded `38` → actual `41` (auto-counted via glob)
+- `task_count`: hardcoded "specs 1-10 + INDEX" → actual `11`
+- Tree was missing `GEMINI.md` (added Apr 21 via PR #72)
+- Tree was missing `challenges/` (added Apr 20 via PR #82)
+- `bin/` was missing `complexity-check`, `score-all`, `regen-diagrams`
+
+**Auto-counts** computed at regen time:
+- `findings_count`: glob `findings/exp_*.md`
+- `experiments_jsonl_count`: line count of `research/log.jsonl`
+- `task_count`: glob `docs/tasks/[0-9]*-*.md`
+
+**Contributor workflow:** edit `_diagrams.yaml` → run `bin/regen-diagrams` → commit YAML + regenerated `.md` files. CI catches PRs that edit the YAML without regen-ing.
+
 ### Documentation hygiene
 
 - **Broken mkdocs link fixed** in `docs/tasks/009-muon-review.md` — `../../research/search_space.yaml` (lives outside docs tree) replaced with a GitHub URL. `mkdocs build --strict` now passes clean (only the unrelated MkDocs 2.0 framework deprecation banner remains).
@@ -49,6 +69,7 @@ Yellow `#FBCA04`, description "Spec posted, awaiting follow-up implementation." 
 | #87 | exp: ByteDMD floor-gap survey — KM-min 268 vs GF(2) 101,501 | @SethTS |
 | #88 | exp: extend floor-gap survey with Fourier + SGD-demo + geometric LB | @0bserver07 |
 | #89 | docs(sync): Google Docs refresh + untracked plans/lockfile cleanup | @0bserver07 |
+| #91 | diagrams: single source of truth + bin/regen-diagrams + CI staleness check | @0bserver07 |
 
 ## [0.28.0] - 2026-04-20
 


### PR DESCRIPTION
## Summary

Companion PR to #91. Two doc updates:

### 1. Changelog (Option B — new section in v0.29.0)

Added "Auto-generated repo diagrams (PR #91)" section in `docs/changelog.md` covering:
- The single-source-of-truth YAML + `bin/regen-diagrams` + CI staleness check
- Drift caught on first regen (38→41 findings, missing GEMINI.md, etc.)
- Auto-count placeholders
- Contributor workflow

PR #91 added to "Pull requests landed" table.

### 2. CONTRIBUTING.md additions

- **Branch protection note** in PR process (1 approval required, admin override for hotfixes, force-push and deletion blocked)
- **Updating the repo diagrams** section — edit YAML → run `bin/regen-diagrams` → commit, with the list of auto-counted placeholders
- **Releases and version tags** section — SemVer + Keep a Changelog convention, annotated tag at the merge commit, push pattern (`git tag -a v0.X.0 <sha> -m ...`)

The version-tags section sets up a follow-up: the repo currently has zero git tags despite 8+ released versions in the changelog. Adding them retroactively can be a separate PR.

## Test plan

- [x] `python3 -m mkdocs build --strict` passes
- [x] No code changes; pure docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)