### PR TITLE
docs(contrib): note version-tag coverage cutoff

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -186,6 +186,8 @@ git push origin v0.X.0
 
 Tag the **merge commit** that landed the changelog entry, not your feature branch.
 
+**Tag coverage:** v0.16.0, v0.17.0, v0.23.0, v0.24.0, v0.25.0, v0.27.0, v0.28.0, v0.29.0. Earlier releases (v0.5.0–v0.15.0, v0.18.0–v0.22.0, v0.26.0) are documented in `docs/changelog.md` but have no git tags — the corresponding commits couldn't be unambiguously identified retroactively. Use the changelog as the authoritative source for those versions.
+
 ## Questions
 
 Ask in the [Telegram group](https://t.me/sutro_group) or open a GitHub issue.


### PR DESCRIPTION
Tiny follow-up to #92. Adds one paragraph to the "Releases and version tags" section noting which versions have tags (8: v0.16.0, v0.17.0, v0.23.0, v0.24.0, v0.25.0, v0.27.0, v0.28.0, v0.29.0) and which earlier releases stay documented-only in the changelog because their commits couldn't be unambiguously identified retroactively.

🤖 Generated with [Claude Code](https://claude.com/claude-code)